### PR TITLE
Allow pod annotations for the daemonset

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -32,6 +32,10 @@ spec:
       labels:
         {{- include "dcgm-exporter.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "dcgm-exporter"
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -46,6 +46,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
This is useful when using Prometheus but not with an operator so can tell Prometheus to scrape the pod port.