### PR TITLE
Allow disabling service

### DIFF
--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enable }}
 # Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,3 +34,4 @@ spec:
     protocol: TCP
   selector:
     {{- include "dcgm-exporter.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -57,6 +57,7 @@ securityContext:
   # readOnlyRootFilesystem: true
 
 service:
+  enable: true
   type: ClusterIP
   port: 9400
   address: ":9400"


### PR DESCRIPTION
We scrape the pod port directly. Plus scraping the service doesn't really work with daemonset since the service will point to only one of the daemonset pods, and when more than one node exists with GPUs, this ends up not scraping more than one node.