### PR TITLE
enable DCGM_FI_DEV_GPU_UTIL && update docker file

### DIFF
--- a/docker/Dockerfile.ubuntu20.04
+++ b/docker/Dockerfile.ubuntu20.04
@@ -13,6 +13,7 @@ COPY --from=builder /go/src/github.com/NVIDIA/dcgm-exporter/pkg/dcgm-exporter /u
 COPY etc /etc/dcgm-exporter
 
 ARG DCGM_VERSION
+RUN rm /etc/apt/sources.list.d/nvidia-ml.list && rm  /etc/apt/sources.list.d/cuda.list && apt-get clean && apt-get update
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libcap2-bin gnupg2 curl ca-certificates && \
     curl -fsSL https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub | apt-key add - && \

--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -20,7 +20,7 @@ DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since bo
 DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 
 # Utilization (the sample period varies depending on the product),,
-# DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
+DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
 DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
 DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
 DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).


### PR DESCRIPTION
Hello, friends. 
Thanks to this repo, we can install DCGM exporter using Helm and fetch metrics using Prometheus.
However, I have a puzzle right now.
Why do we close the metrics label DCGM_FI_DEV_GPU_UTIL ? 
Hope that someone can help to answer this question.
Thank you in advance.

BTW, this pr aims to enable metrics label DCGM_FI_DEV_GPU_UTIL  and fix a build error in Dockerfile.
The error like below:
```
E: Failed to fetch https://developer.download.nvidia.cn/compute/cuda/repos/ubuntu2004/x86_64/by-hash/SHA256/751939d95516afc289908a19e447f0acc1506367f72ed356431a2b1a469cc8ca  404  Not Found [IP: 45.43.32.211 443]
E: Some index files failed to download. They have been ignored, or old ones used instead.
```
Thank you for your reply.
