### PR TITLE
#fixed: failed to add annotations

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -32,9 +32,9 @@ spec:
       labels:
         {{- include "dcgm-exporter.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "dcgm-exporter"
-      {{- with .Values.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -50,6 +50,10 @@ serviceAccount:
   name:
 
 podAnnotations: {}
+# Using this annotation which is required for prometheus scraping
+ # prometheus.io/scrape: "true"
+ # prometheus.io/port: "9400"
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
Failed to add annotation by using helm tool
Reason: it's missing podAnnotations values in annotation block at template spec

Purpose:
- using this annotation that is required for prometheus scraping


In values.yml should be
```
podAnnotations:
 prometheus.io/scrape: "true"
 prometheus.io/port: "9400"
```