### PR TITLE
fix: add role to read the cm

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: exporter-metrics-config-map
+  namespace: {{ .Release.Namespace }}
 data:
   metrics: |
       # Format,,

--- a/deployment/templates/role.yaml
+++ b/deployment/templates/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dcgm-exporter-read-cm
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "dcgm-exporter"
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["exporter-metrics-config-map"]
+  verbs: ["get"]

--- a/deployment/templates/rolebinding.yaml
+++ b/deployment/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+    app.kubernetes.io/component: "dcgm-exporter"
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dcgm-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role 
+  name: dcgm-exporter-read-cm
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
fix: add role to read the cm 

```
Could not retrieve ConfigMap 'monitoring:exporter-metrics-volume': configmaps \"exporter-metrics-volume\" is forbidden:
User \"system:serviceaccount:monitoring:dcgm-exporter\" cannot get resource \"configmaps\" in API group \"\" in the namespace \"monitoring\", falling back to metric file /etc/dcgm-exporter/dcp-metrics-included.csv
```

Signed-off-by: Cyril Corbon <corboncyril@gmail.com>