### PR TITLE
Fix setcap check in docker entrypoint

### DIFF
--- a/docker/dcgm-exporter-entrypoint.sh
+++ b/docker/dcgm-exporter-entrypoint.sh
@@ -4,8 +4,7 @@ set -euo pipefail
 # We want to setcap only when the container is started with the right caps
 DCGM_EXPORTER=$(readlink -f $(which dcgm-exporter))
 if [ -z "$NO_SETCAP" ]; then
-   setcap 'cap_sys_admin=+ep' $DCGM_EXPORTER
-   if [ $? -eq 0 ]; then
+   if setcap 'cap_sys_admin=+ep' $DCGM_EXPORTER; then
       if ! $DCGM_EXPORTER -v 1>/dev/null 2>/dev/null; then
          >&2 echo "Warning #2: dcgm-exporter doesn't have sufficient privileges to expose profiling metrics. To get profiling metrics with dcgm-exporter, use --cap-add SYS_ADMIN"
          setcap 'cap_sys_admin=-ep' $DCGM_EXPORTER


### PR DESCRIPTION
The warnings are never printed because the script uses 'set -e'. Please consider either cleaning up by deleting the unused code or fixing it to work as intended (this MR).

Before:
```
$ enroot start nvidia+k8s+dcgm-exporter+2.3.4-2.6.4-ubuntu20.04
unable to set CAP_SETFCAP effective capability: Operation not permitted
$ echo $?
1
```
After:
```
$ enroot start nvidia+k8s+dcgm-exporter+2.3.4-2.6.4-ubuntu20.04
unable to set CAP_SETFCAP effective capability: Operation not permitted
Warning #1: dcgm-exporter doesn't have sufficient privileges to expose profiling metrics. To get profiling metrics with dcgm-exporter, use --cap-add SYS_ADMIN
INFO[0000] Starting dcgm-exporter
INFO[0000] DCGM successfully initialized!
INFO[0000] Collecting DCP Metrics
INFO[0000] No configmap data specified, falling back to metric file /etc/dcgm-exporter/default-counters.csv
INFO[0001] Pipeline starting
INFO[0001] Starting webserver
```