### PR TITLE
Don't require csv comments to have 2 commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ You will find the default CSV file under `etc/default-counters.csv` in the repos
 
 The layout and format of this file is as follows:
 ```
-# Format,,
-# If line starts with a '#' it is considered a comment,,
+# Format
+# If line starts with a '#' it is considered a comment
 # DCGM FIELD, Prometheus metric type, help message
 
-# Clocks,,
+# Clocks
 DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
 DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
 ```

--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -5,34 +5,34 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   metrics: |
-      # Format,,
-      # If line starts with a '#' it is considered a comment,,
+      # Format
+      # If line starts with a '#' it is considered a comment
       # DCGM FIELD, Prometheus metric type, help message
       
-      # Clocks,,
+      # Clocks
       DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
       DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
       
-      # Temperature,,
+      # Temperature
       DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
       DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
       
-      # Power,,
+      # Power
       DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
       DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
       
-      # PCIE,,
+      # PCIE
       # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
       # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
       DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
       
-      # Utilization (the sample period varies depending on the product),,
+      # Utilization (the sample period varies depending on the product)
       DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
       DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
       DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
       DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
       
-      # Errors and violations,,
+      # Errors and violations
       DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
       # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
       # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
@@ -41,22 +41,22 @@ data:
       # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
       # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
       
-      # Memory usage,,
+      # Memory usage
       DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
       DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
       
-      # ECC,,
+      # ECC
       # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
       # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
       # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
       # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
       
-      # Retired pages,,
+      # Retired pages
       # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
       # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
       # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
       
-      # NVLink,,
+      # NVLink
       # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
       # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
       # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
@@ -64,15 +64,15 @@ data:
       DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
       # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
       
-      # VGPU License status,,
+      # VGPU License status
       DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
       
-      # Remapped rows,,
+      # Remapped rows
       DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
       DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
       DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
       
-      # DCP metrics,,
+      # DCP metrics
       DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
       # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
       # DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM (in %).

--- a/etc/1.x-compatibility-metrics.csv
+++ b/etc/1.x-compatibility-metrics.csv
@@ -1,31 +1,31 @@
-# Format,,
-# If line starts with a '#' it is considered a comment,,
+# Format
+# If line starts with a '#' it is considered a comment
 # DCGM FIELD, Prometheus metric type, help message
 
-# Clocks,,
+# Clocks
 dcgm_sm_clock,     gauge, SM clock frequency (in MHz).
 dcgm_memory_clock, gauge, Memory clock frequency (in MHz).
 
-# Temperature,,
+# Temperature
 dcgm_memory_temp, gauge, Memory temperature (in C).
 dcgm_gpu_temp,    gauge, GPU temperature (in C).
 
-# Power,,
+# Power
 dcgm_power_usage,              gauge, Power draw (in W).
 dcgm_total_energy_consumption, counter, Total energy consumption since boot (in mJ).
 
-# PCIe,,
+# PCIe
 dcgm_pcie_tx_throughput,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
 dcgm_pcie_rx_throughput,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
 dcgm_pcie_replay_counter, counter, Total number of PCIe retries.
 
-# Utilization (the sample period varies depending on the product),,
+# Utilization (the sample period varies depending on the product)
 dcgm_gpu_utilization,      gauge, GPU utilization (in %).
 dcgm_mem_copy_utilization, gauge, Memory utilization (in %).
 dcgm_enc_utilization,      gauge, Encoder utilization (in %).
 dcgm_dec_utilization,      gauge, Decoder utilization (in %).
 
-# Errors and violations,,
+# Errors and violations
 dcgm_xid_errors,            gauge, Value of the last XID error encountered.
 # dcgm_power_violation,       counter, Throttling duration due to power constraints (in us).
 # dcgm_thermal_violation,     counter, Throttling duration due to thermal constraints (in us).
@@ -34,29 +34,29 @@ dcgm_xid_errors,            gauge, Value of the last XID error encountered.
 # dcgm_low_util_violation,    counter, Throttling duration due to low utilization (in us).
 # dcgm_reliability_violation, counter, Throttling duration due to reliability constraints (in us).
 
-# Memory usage,,
+# Memory usage
 dcgm_fb_free, gauge, Framebuffer memory free (in MiB).
 dcgm_fb_used, gauge, Framebuffer memory used (in MiB).
 
-# ECC,,
+# ECC
 # dcgm_ecc_sbe_volatile_total,  counter, Total number of single-bit volatile ECC errors.
 # dcgm_ecc_dbe_volatile_total,  counter, Total number of double-bit volatile ECC errors.
 # dcgm_ecc_sbe_aggregate_total, counter, Total number of single-bit persistent ECC errors.
 # dcgm_ecc_dbe_aggregate_total, counter, Total number of double-bit persistent ECC errors.
 
-# Retired pages,,
+# Retired pages
 # dcgm_retired_pages_sbe,     counter, Total number of retired pages due to single-bit errors.
 # dcgm_retired_pages_dbe,     counter, Total number of retired pages due to double-bit errors.
 # dcgm_retired_pages_pending, counter, Total number of pages pending retirement.
 
-# NVLink,,
+# NVLink
 # dcgm_nvlink_flit_crc_error_count_total, counter, Total number of NVLink flow-control CRC errors.
 # dcgm_nvlink_data_crc_error_count_total, counter, Total number of NVLink data CRC errors.
 # dcgm_nvlink_replay_error_count_total,   counter, Total number of NVLink retries.
 # dcgm_nvlink_recovery_error_count_total, counter, Total number of NVLink recovery errors.
 dcgm_nvlink_bandwidth_total,            counter, Total number of NVLink bandwidth counters for all lanes
 
-# Add DCP metrics,,
+# Add DCP metrics
 dcgm_fi_prof_gr_engine_active,   gauge, Ratio of time the graphics engine is active (in %).
 # dcgm_fi_prof_sm_active,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
 # dcgm_fi_prof_sm_occupancy,       gauge, The ratio of number of warps resident on an SM (in %).

--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -1,31 +1,31 @@
-# Format,,
-# If line starts with a '#' it is considered a comment,,
+# Format
+# If line starts with a '#' it is considered a comment
 # DCGM FIELD, Prometheus metric type, help message
 
-# Clocks,,
+# Clocks
 DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
 DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
 
-# Temperature,,
+# Temperature
 DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
 DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
 
-# Power,,
+# Power
 DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
-# PCIE,,
+# PCIE
 # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
 # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
 DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 
-# Utilization (the sample period varies depending on the product),,
+# Utilization (the sample period varies depending on the product)
 DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
 DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
 DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
 DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 
-# Errors and violations,,
+# Errors and violations
 DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
 # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
 # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
@@ -34,22 +34,22 @@ DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encounte
 # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
 # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
 
-# Memory usage,,
+# Memory usage
 DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
 DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
 
-# ECC,,
+# ECC
 # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
 # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
 # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
 # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
 
-# Retired pages,,
+# Retired pages
 # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
 # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
 # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
 
-# NVLink,,
+# NVLink
 # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
 # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
@@ -57,15 +57,15 @@ DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
 DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
 # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
 
-# VGPU License status,,
+# VGPU License status
 DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
 
-# Remapped rows,,
+# Remapped rows
 DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
 
-# DCP metrics,,
+# DCP metrics
 DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
 # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
 # DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM (in %).

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -1,31 +1,31 @@
-# Format,,
-# If line starts with a '#' it is considered a comment,,
+# Format
+# If line starts with a '#' it is considered a comment
 # DCGM FIELD, Prometheus metric type, help message
 
-# Clocks,,
+# Clocks
 DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
 DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
 
-# Temperature,,
+# Temperature
 DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
 DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
 
-# Power,,
+# Power
 DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
-# PCIE,,
+# PCIE
 DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
 DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
 DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 
-# Utilization (the sample period varies depending on the product),,
+# Utilization (the sample period varies depending on the product)
 DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
 DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
 DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
 DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 
-# Errors and violations,,
+# Errors and violations
 DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
 # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
 # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
@@ -34,32 +34,32 @@ DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encounte
 # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
 # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
 
-# Memory usage,,
+# Memory usage
 DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
 DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
 
-# ECC,,
+# ECC
 # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
 # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
 # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
 # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
 
-# Retired pages,,
+# Retired pages
 # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
 # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
 # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
 
-# NVLink,,
+# NVLink
 # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
 # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
 # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
 DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes
 
-# VGPU License status,,
+# VGPU License status
 DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
 
-# Remapped rows,,
+# Remapped rows
 DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed

--- a/pkg/dcgmexporter/parser.go
+++ b/pkg/dcgmexporter/parser.go
@@ -73,6 +73,7 @@ func ReadCSVFile(filename string) ([][]string, error) {
 	defer file.Close()
 
 	r := csv.NewReader(file)
+	r.Comment = '#'
 	records, err := r.ReadAll()
 
 	return records, err
@@ -89,11 +90,6 @@ func extractCounters(records [][]string, dcpAllowed bool) ([]Counter, error) {
 
 		for j, r := range record {
 			record[j] = strings.Trim(r, " ")
-		}
-
-		if recordIsCommentOrEmpty(record) {
-			logrus.Debugf("Skipping line %d (`%v`)", i, record)
-			continue
 		}
 
 		if len(record) != 3 {
@@ -137,18 +133,6 @@ func extractCounters(records [][]string, dcpAllowed bool) ([]Counter, error) {
 	}
 
 	return f, nil
-}
-
-func recordIsCommentOrEmpty(s []string) bool {
-	if len(s) == 0 {
-		return true
-	}
-
-	if len(s[0]) < 1 || s[0][0] == '#' {
-		return true
-	}
-
-	return false
 }
 
 func readConfigMap(kubeClient kubernetes.Interface, c *Config) ([][]string, error) {


### PR DESCRIPTION
Also remove the check for empty lines because encoding/csv's parser already does this automatically.