### PR TITLE
makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ SYSCONFDIR := $(abspath $(DESTDIR))$(sysconfdir)
 GO      ?= go
 GOFLAGS ?=
 
-MKDIR    ?= mkdir
 REGISTRY ?= nvidia
 
 DCGM_VERSION   := 2.3.5

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+prefix     ?= /usr/local
+bindir     ?= $(prefix)/bin
+sysconfdir ?= $(prefix)/etc
+
+BINDIR     := $(abspath $(DESTDIR))$(bindir)
+SYSCONFDIR := $(abspath $(DESTDIR))$(sysconfdir)
+
 MKDIR    ?= mkdir
 REGISTRY ?= nvidia
 
@@ -39,9 +46,8 @@ test-main: $(NON_TEST_FILES) $(MAIN_TEST_FILES)
 	go test ./...
 
 install: binary
-	install -m 557 cmd/dcgm-exporter/dcgm-exporter /usr/bin/dcgm-exporter
-	install -m 557 -D ./etc/default-counters.csv /etc/dcgm-exporter/default-counters.csv
-	install -m 557 -D ./etc/dcp-metrics-included.csv /etc/dcgm-exporter/dcp-metrics-included.csv
+	install -m 0755 -D -t $(BINDIR) cmd/dcgm-exporter/dcgm-exporter
+	install -m 0644 -D -t $(SYSCONFDIR)/dcgm-exporter/ etc/default-counters.csv etc/dcp-metrics-included.csv
 
 check-format:
 	test $$(gofmt -l pkg | tee /dev/stderr | wc -l) -eq 0

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ binary:
 test-main: $(NON_TEST_FILES) $(MAIN_TEST_FILES)
 	$(GO) test ./...
 
-install: binary
+install:
 	install -m 0755 -D -t $(BINDIR) cmd/dcgm-exporter/dcgm-exporter
 	install -m 0644 -D -t $(SYSCONFDIR)/dcgm-exporter/ etc/default-counters.csv etc/dcp-metrics-included.csv
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ sysconfdir ?= $(prefix)/etc
 BINDIR     := $(abspath $(DESTDIR))$(bindir)
 SYSCONFDIR := $(abspath $(DESTDIR))$(sysconfdir)
 
+GO      ?= go
+GOFLAGS ?=
+
 MKDIR    ?= mkdir
 REGISTRY ?= nvidia
 
@@ -40,10 +43,10 @@ MAIN_TEST_FILES := pkg/dcgmexporter/system_info_test.go
 all: ubuntu20.04 ubi8
 
 binary:
-	cd cmd/dcgm-exporter; go build -ldflags "-X main.BuildVersion=${DCGM_VERSION}-${VERSION}"
+	cd cmd/dcgm-exporter; $(GO) build $(GOFLAGS) -ldflags "-X main.BuildVersion=${DCGM_VERSION}-${VERSION}"
 
 test-main: $(NON_TEST_FILES) $(MAIN_TEST_FILES)
-	go test ./...
+	$(GO) test ./...
 
 install: binary
 	install -m 0755 -D -t $(BINDIR) cmd/dcgm-exporter/dcgm-exporter


### PR DESCRIPTION
NOTE: this makes two breaking changes to the 'install' target:
1. Files are now installed to "standard" locations such as /usr/local/bin/ instead of /usr/bin/. To get back to the old behavior:
    `sudo make prefix=/usr sysconfdir=/etc install`.
1. The install target no longer depends on the binary target, which could break build workflows which only run `make install`. This could be fixed with additional work.