### PR TITLE
[add]: support for `hostNetwork` parameter in daemonset deployment

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -37,6 +37,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -39,6 +39,7 @@ spec:
     spec:
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
If hostNetwork parameter is set to `true`  then host ip is assigned to the daemonset instead of assigning a new ip.

This can be set to true, when:
- Daemonset is not externallly accessed.
- It saves an Ip address.

If `hostNetwork` is available  in values yaml. and value is 'true' then add the hostNetwork parameter to template spec.

spec:
      {{- if .Values.hostNetwork }}
      hostNetwork: {{ .Values.hostNetwork }}
      {{- end }}

Signed-off-by: Vasudev Singh C <vasudev.singhc@jda.com>