### PR TITLE
Support export of string metrics as labels

### DIFF
--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -65,6 +65,17 @@ DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for un
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
 
+# Static configuration information. These appear as labels on a dcgm_exporter_info metric.
+DCGM_FI_DRIVER_VERSION,        label, Driver Version
+DCGM_FI_NVML_VERSION,          label, NVML Version
+DCGM_FI_DEV_BRAND,             label, Device Brand
+DCGM_FI_DEV_SERIAL,            label, Device Serial Number
+DCGM_FI_DEV_OEM_INFOROM_VER,   label, OEM inforom version
+DCGM_FI_DEV_ECC_INFOROM_VER,   label, ECC inforom version
+DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
+DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
+DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device
+
 # DCP metrics
 DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
 # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -65,4 +65,12 @@ DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for co
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
 
 # Static configuration information. These appear as labels on a dcgm_exporter_info metric.
-DCGM_FI_DRIVER_VERSION, label, Driver Version
+DCGM_FI_DRIVER_VERSION,        label, Driver Version
+DCGM_FI_NVML_VERSION,          label, NVML Version
+DCGM_FI_DEV_BRAND,             label, Device Brand
+DCGM_FI_DEV_SERIAL,            label, Device Serial Number
+DCGM_FI_DEV_OEM_INFOROM_VER,   label, OEM inforom version
+DCGM_FI_DEV_ECC_INFOROM_VER,   label, ECC inforom version
+DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
+DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
+DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -63,3 +63,6 @@ DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
 DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+
+# Static configuration information. These appear as labels on a dcgm_exporter_info metric.
+DCGM_FI_DRIVER_VERSION, label, Driver Version

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -16,10 +16,12 @@
 
 package dcgmexporter
 
+import "C"
 import (
 	"fmt"
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"os"
+	"unsafe"
 )
 
 func NewDCGMCollector(c []Counter, config *Config) (*DCGMCollector, func(), error) {
@@ -145,42 +147,60 @@ func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceI
 	return metrics
 }
 
+func fieldValueString(value dcgm.FieldValue_v1) string {
+	// Workaround for https://github.com/NVIDIA/go-dcgm/issues/18
+	return C.GoString((*C.char)(unsafe.Pointer(&value.Value[0])))
+}
+
 func ToString(value dcgm.FieldValue_v1) string {
-	switch v := value.Int64(); v {
-	case dcgm.DCGM_FT_INT32_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	}
-	switch v := value.Float64(); v {
-	case dcgm.DCGM_FT_FP64_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	}
-	switch v := value.FieldType; v {
-	case dcgm.DCGM_FT_STRING:
-		return value.String()
-	case dcgm.DCGM_FT_DOUBLE:
-		return fmt.Sprintf("%f", value.Float64())
+	switch value.FieldType {
 	case dcgm.DCGM_FT_INT64:
-		return fmt.Sprintf("%d", value.Int64())
+		switch v := value.Int64(); v {
+		case dcgm.DCGM_FT_INT32_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return fmt.Sprintf("%d", value.Int64())
+		}
+	case dcgm.DCGM_FT_DOUBLE:
+		switch v := value.Float64(); v {
+		case dcgm.DCGM_FT_FP64_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return fmt.Sprintf("%f", value.Float64())
+		}
+	case dcgm.DCGM_FT_STRING:
+		switch v := fieldValueString(value); v {
+		case dcgm.DCGM_FT_STR_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return v
+		}
 	default:
 		return FailedToConvert
 	}

--- a/pkg/dcgmexporter/gpu_collector_test.go
+++ b/pkg/dcgmexporter/gpu_collector_test.go
@@ -28,6 +28,7 @@ var sampleCounters = []Counter{
 	{dcgm.DCGM_FI_DEV_GPU_TEMP, "DCGM_FI_DEV_GPU_TEMP", "gauge", "Temperature Help info"},
 	{dcgm.DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION", "gauge", "Energy help info"},
 	{dcgm.DCGM_FI_DEV_POWER_USAGE, "DCGM_FI_DEV_POWER_USAGE", "gauge", "Power help info"},
+	{dcgm.DCGM_FI_DRIVER_VERSION, "DCGM_FI_DRIVER_VERSION", "label", "Driver Version"},
 }
 
 func TestDCGMCollector(t *testing.T) {

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -43,6 +43,13 @@ var (
 	oldContainerAttribute = "container_name"
 
 	undefinedConfigMapData = "none"
+
+	infoCounter = Counter{
+		FieldID:   dcgm.DCGM_FI_UNKNOWN,
+		FieldName: "dcgm_exporter_info",
+		PromType:  "gauge",
+		Help:      "String values represented as labels",
+	}
 )
 
 type KubernetesGPUIDType string
@@ -143,6 +150,7 @@ var promMetricType = map[string]bool{
 	"counter":   true,
 	"histogram": true,
 	"summary":   true,
+	"label":     true,
 }
 
 type MetricsServer struct {


### PR DESCRIPTION
Counters may be defined with a Prometheus type of "label". These get
exported as labels on a `dcgm_exxporter_info` metric to Prometheus.

Closes https://github.com/NVIDIA/dcgm-exporter/issues/72.