### PR TITLE
Allow specifying honorLabels in ServiceMonitor spec

### DIFF
--- a/deployment/templates/service-monitor.yaml
+++ b/deployment/templates/service-monitor.yaml
@@ -36,4 +36,5 @@ spec:
   - port: "metrics"
     path: "/metrics"
     interval: "{{ .Values.serviceMonitor.interval }}"
+    honorLabels: {{ .Values.serviceMonitor.honorLabels }}
 {{- end -}}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -83,6 +83,7 @@ resources: {}
 serviceMonitor:
   enabled: true
   interval: 15s
+  honorLabels: false
   additionalLabels: {}
     #monitoring: prometheus
 


### PR DESCRIPTION
By default, if metrics are scraped by Prometheus, there will be label conflicts with the labels `container`, `namespace` and `pod`. This is because honor label config when unset defaults to `false`. Label conflicts are resolved by renaming conflicting labels in the scraped data to "exported_<original-label>".

This PR allows specifying `honorLabels` in the endpoint specification of ServiceMonitor. When this field is set `true`, label conflicts are resolved by keeping label values from the scraped data. 

Signed-off-by: Chris Sng <chrissng@users.noreply.github.com>