### PR TITLE
82 - query supported metric groups and skip unsupported

### DIFF
--- a/cmd/dcgm-exporter/main.go
+++ b/cmd/dcgm-exporter/main.go
@@ -211,12 +211,14 @@ restart:
 	dcgm.FieldsInit()
 	defer dcgm.FieldsTerm()
 
-	_, err = dcgm.GetSupportedMetricGroups(0)
+	var groups []dcgm.MetricGroup
+	groups, err = dcgm.GetSupportedMetricGroups(0)
 	if err != nil {
 		config.CollectDCP = false
 		logrus.Info("Not collecting DCP metrics: ", err)
 	} else {
 		logrus.Info("Collecting DCP Metrics")
+		config.MetricGroups = groups
 	}
 
 	ch := make(chan string, 10)

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ replace (
 )
 
 require (
-	github.com/NVIDIA/go-dcgm v0.0.0-20220719175406-02d37f80fd94
+	github.com/NVIDIA/go-dcgm v0.0.0-20220728130116-32999852818d
 	github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/NVIDIA/go-dcgm v0.0.0-20220625061956-d4ffb2091c7c h1:uEvU/Oc5vRFMf71D
 github.com/NVIDIA/go-dcgm v0.0.0-20220625061956-d4ffb2091c7c/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
 github.com/NVIDIA/go-dcgm v0.0.0-20220719175406-02d37f80fd94 h1:AbHbjiyjncJf4zyhFZaGksNzsev8WJLO7hEfjrQJ6Zg=
 github.com/NVIDIA/go-dcgm v0.0.0-20220719175406-02d37f80fd94/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
+github.com/NVIDIA/go-dcgm v0.0.0-20220728130116-32999852818d h1:3TQlcJb+uuhuMrBiqVbWBimTHlSrpn6zV/ATSMgO2YQ=
+github.com/NVIDIA/go-dcgm v0.0.0-20220728130116-32999852818d/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
 github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48 h1:JO/JF5CBte9mvATbhoh32swu9erf07ZdLgwFj8u21UQ=
 github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48/go.mod h1:oKPJa5eOTkWvlT4/Y4D8Nds44Fzmww5HUK+xwO+DwTA=
 github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm v0.0.0-20210325210537-29b4f1784f18/go.mod h1:8qXwltEzU3idjUcVpMOv3FNgxxbDeXZPGMLyc/khWiY=

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -72,6 +72,7 @@ type Config struct {
 	NoHostname          bool
 	UseFakeGpus         bool
 	ConfigMapData       string
+	MetricGroups        []dcgm.MetricGroup
 }
 
 type Transform interface {


### PR DESCRIPTION
Before:
```
# dcgm-exporter -f etc/dcgm-exporter/dcp-metrics-included.csv
INFO[0000] Starting dcgm-exporter
INFO[0000] DCGM successfully initialized!
INFO[0000] Collecting DCP Metrics
INFO[0000] No configmap data specified, falling back to metric file etc/dcgm-exporter/dcp-metrics-included.csv
FATA[0001] Error watching fields: Feature not supported
```
Now:
```
dcgm-exporter -f etc/dcgm-exporter/dcp-metrics-included.csv
INFO[0000] Starting dcgm-exporter
INFO[0000] DCGM successfully initialized!
INFO[0000] Collecting DCP Metrics
INFO[0000] No configmap data specified, falling back to metric file etc/dcgm-exporter/dcp-metrics-included.csv
WARN[0000] Skipping line 24 ('DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE'): metric not enabled
WARN[0000] Skipping line 25 ('DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE'): metric not enabled
INFO[0001] Starting webserver
INFO[0001] Pipeline starting
```