### PR TITLE
Fix the type of the PCIE_TX/RX metrics and provide more accurate description.

### DIFF
--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -74,6 +74,6 @@ DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interf
 # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active (in %).
 # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active (in %).
 # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active (in %).
-DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
-DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus, including both protocol headers and data payloads, in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus, including both protocol headers and data payloads, in bytes per second.
 


### PR DESCRIPTION
DCGM_FI_PROF_PCIE_TX_BYTES and DCGM_FI_PROF_PCIE_RX_BYTES are PCIe bandwidths that are computed for each scraping interval. The types of those metrics were mistakenly specified as 'counter' instead of 'gauge.' 
The descriptions of those metrics were also updated according to the official DCGM documentation.The descriptions of those metrics were also updated according to the officidal DCGM documentation.