### PR TITLE
Add support for string fields as labels

### DIFF
--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -65,6 +65,17 @@ DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for un
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
 
+# Static configuration information. These appear as labels on the other metrics
+DCGM_FI_DRIVER_VERSION,        label, Driver Version
+# DCGM_FI_NVML_VERSION,          label, NVML Version
+# DCGM_FI_DEV_BRAND,             label, Device Brand
+# DCGM_FI_DEV_SERIAL,            label, Device Serial Number
+# DCGM_FI_DEV_OEM_INFOROM_VER,   label, OEM inforom version
+# DCGM_FI_DEV_ECC_INFOROM_VER,   label, ECC inforom version
+# DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
+# DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
+# DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device
+
 # DCP metrics
 DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
 # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -63,3 +63,14 @@ DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
 DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
 DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
 DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+
+# Static configuration information. These appear as labels on the other metrics
+DCGM_FI_DRIVER_VERSION,        label, Driver Version
+# DCGM_FI_NVML_VERSION,          label, NVML Version
+# DCGM_FI_DEV_BRAND,             label, Device Brand
+# DCGM_FI_DEV_SERIAL,            label, Device Serial Number
+# DCGM_FI_DEV_OEM_INFOROM_VER,   label, OEM inforom version
+# DCGM_FI_DEV_ECC_INFOROM_VER,   label, ECC inforom version
+# DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
+# DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
+# DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -119,41 +119,54 @@ func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceI
 }
 
 func ToString(value dcgm.FieldValue_v1) string {
-	switch v := value.Int64(); v {
-	case dcgm.DCGM_FT_INT32_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT32_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_INT64_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	}
-	switch v := value.Float64(); v {
-	case dcgm.DCGM_FT_FP64_BLANK:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_FOUND:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_SUPPORTED:
-		return SkipDCGMValue
-	case dcgm.DCGM_FT_FP64_NOT_PERMISSIONED:
-		return SkipDCGMValue
-	}
-	switch v := value.FieldType; v {
-	case dcgm.DCGM_FT_STRING:
-		return value.String()
-	case dcgm.DCGM_FT_DOUBLE:
-		return fmt.Sprintf("%f", value.Float64())
+	switch value.FieldType {
 	case dcgm.DCGM_FT_INT64:
-		return fmt.Sprintf("%d", value.Int64())
+		switch v := value.Int64(); v {
+		case dcgm.DCGM_FT_INT32_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT32_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_INT64_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return fmt.Sprintf("%d", value.Int64())
+		}
+	case dcgm.DCGM_FT_DOUBLE:
+		switch v := value.Float64(); v {
+		case dcgm.DCGM_FT_FP64_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_FP64_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return fmt.Sprintf("%f", value.Float64())
+		}
+	case dcgm.DCGM_FT_STRING:
+		switch v := value.String(); v {
+		case dcgm.DCGM_FT_STR_BLANK:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_FOUND:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_SUPPORTED:
+			return SkipDCGMValue
+		case dcgm.DCGM_FT_STR_NOT_PERMISSIONED:
+			return SkipDCGMValue
+		default:
+			return v
+		}
 	default:
 		return FailedToConvert
 	}

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -81,11 +81,16 @@ func (c *DCGMCollector) GetMetrics() ([][]Metric, error) {
 
 func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceInfo *GpuInstanceInfo, useOld bool, hostname string) []Metric {
 	var metrics []Metric
+	var labels = map[string]string{}
 
 	for i, val := range values {
 		v := ToString(val)
 		// Filter out counters with no value and ignored fields for this entity
 		if v == SkipDCGMValue {
+			continue
+		}
+		if c[i].PromType == "label" {
+			labels[c[i].FieldName] = v
 			continue
 		}
 		uuid := "UUID"
@@ -103,6 +108,7 @@ func ToMetric(values []dcgm.FieldValue_v1, c []Counter, d dcgm.Device, instanceI
 			GPUModelName: d.Identifiers.Model,
 			Hostname:     hostname,
 
+			Labels:     &labels,
 			Attributes: map[string]string{},
 		}
 		if instanceInfo != nil {

--- a/pkg/dcgmexporter/gpu_collector_test.go
+++ b/pkg/dcgmexporter/gpu_collector_test.go
@@ -31,10 +31,10 @@ var sampleCounters = []Counter{
 	{dcgm.DCGM_FI_DRIVER_VERSION, "DCGM_FI_DRIVER_VERSION", "label", "Driver version"},
 }
 
-var expectedMetrics = []string{
-	"DCGM_FI_DEV_GPU_TEMP",
-	"DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION",
-	"DCGM_FI_DEV_POWER_USAGE",
+var expectedMetrics = map[string]bool{
+	"DCGM_FI_DEV_GPU_TEMP":                 true,
+	"DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION": true,
+	"DCGM_FI_DEV_POWER_USAGE":              true,
 }
 
 func TestDCGMCollector(t *testing.T) {
@@ -63,13 +63,15 @@ func testDCGMCollector(t *testing.T, counters []Counter) (*DCGMCollector, func()
 	require.Len(t, out[0], len(expectedMetrics))
 
 	for i, dev := range out {
-		for j, metric := range dev {
-			require.Equal(t, metric.Counter.FieldName, expectedMetrics[j])
+		seenMetrics := map[string]bool{}
+		for _, metric := range dev {
+			seenMetrics[metric.Counter.FieldName] = true
 			require.Equal(t, metric.GPU, fmt.Sprintf("%d", i))
 
 			require.NotEmpty(t, metric.Value)
 			require.NotEqual(t, metric.Value, FailedToConvert)
 		}
+		require.Equal(t, seenMetrics, expectedMetrics)
 	}
 
 	return c, cleanup

--- a/pkg/dcgmexporter/gpu_collector_test.go
+++ b/pkg/dcgmexporter/gpu_collector_test.go
@@ -31,6 +31,12 @@ var sampleCounters = []Counter{
 	{dcgm.DCGM_FI_DRIVER_VERSION, "DCGM_FI_DRIVER_VERSION", "label", "Driver version"},
 }
 
+var expectedMetrics = []string{
+	"DCGM_FI_DEV_GPU_TEMP",
+	"DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION",
+	"DCGM_FI_DEV_POWER_USAGE",
+}
+
 func TestDCGMCollector(t *testing.T) {
 	cleanup, err := dcgm.Init(dcgm.Embedded)
 	require.NoError(t, err)
@@ -54,10 +60,11 @@ func testDCGMCollector(t *testing.T, counters []Counter) (*DCGMCollector, func()
 	out, err := c.GetMetrics()
 	require.NoError(t, err)
 	require.Greater(t, len(out), 0, "Check that you have a GPU on this node")
-	require.Len(t, out[0], len(counters))
+	require.Len(t, out[0], len(expectedMetrics))
 
 	for i, dev := range out {
-		for _, metric := range dev {
+		for j, metric := range dev {
+			require.Equal(t, metric.Counter.FieldName, expectedMetrics[j])
 			require.Equal(t, metric.GPU, fmt.Sprintf("%d", i))
 
 			require.NotEmpty(t, metric.Value)

--- a/pkg/dcgmexporter/gpu_collector_test.go
+++ b/pkg/dcgmexporter/gpu_collector_test.go
@@ -28,6 +28,7 @@ var sampleCounters = []Counter{
 	{dcgm.DCGM_FI_DEV_GPU_TEMP, "DCGM_FI_DEV_GPU_TEMP", "gauge", "Temperature Help info"},
 	{dcgm.DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, "DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION", "gauge", "Energy help info"},
 	{dcgm.DCGM_FI_DEV_POWER_USAGE, "DCGM_FI_DEV_POWER_USAGE", "gauge", "Power help info"},
+	{dcgm.DCGM_FI_DRIVER_VERSION, "DCGM_FI_DRIVER_VERSION", "label", "Driver version"},
 }
 
 func TestDCGMCollector(t *testing.T) {

--- a/pkg/dcgmexporter/pipeline.go
+++ b/pkg/dcgmexporter/pipeline.go
@@ -144,6 +144,9 @@ var metricsFormat = `
 {{- range $metric := $metrics }}
 {{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"
 
+{{- range $k, $v := $metric.Labels -}}
+	,{{ $k }}="{{ $v }}"
+{{- end -}}
 {{- range $k, $v := $metric.Attributes -}}
 	,{{ $k }}="{{ $v }}"
 {{- end -}}
@@ -159,6 +162,9 @@ var migMetricsFormat = `
 {{- range $metric := $metrics }}
 {{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"{{if $metric.MigProfile}},GPU_I_PROFILE="{{ $metric.MigProfile }}",GPU_I_ID="{{ $metric.GPUInstanceID }}"{{end}}{{if $metric.Hostname }},Hostname="{{ $metric.Hostname }}"{{end}}
 
+{{- range $k, $v := $metric.Labels -}}
+	,{{ $k }}="{{ $v }}"
+{{- end -}}
 {{- range $k, $v := $metric.Attributes -}}
 	,{{ $k }}="{{ $v }}"
 {{- end -}}

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -122,6 +122,7 @@ type Metric struct {
 	GPUInstanceID string
 	Hostname      string
 
+	Labels     *map[string]string
 	Attributes map[string]string
 }
 
@@ -144,6 +145,7 @@ var promMetricType = map[string]bool{
 	"counter":   true,
 	"histogram": true,
 	"summary":   true,
+	"label":     true,
 }
 
 type MetricsServer struct {


### PR DESCRIPTION
Any entry in the config file with type "label" will become a label on
all metrics.

Closes https://github.com/NVIDIA/dcgm-exporter/issues/72.