### PR TITLE
feat: add custom hostname CLI and env parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dcgm-exporter
 !etc/
 !deployment/
 tags
+.vscode

--- a/cmd/dcgm-exporter/main.go
+++ b/cmd/dcgm-exporter/main.go
@@ -54,6 +54,7 @@ var (
 	CLIRemoteHEInfo        = "remote-hostengine-info"
 	CLIGPUDevices          = "devices"
 	CLISwitchDevices       = "switch-devices"
+	CLICustomHostname      = "custom-hostname"
 	CLINoHostname          = "no-hostname"
 	CLIUseFakeGpus         = "fake-gpus"
 	CLIConfigMapData       = "configmap-data"
@@ -153,6 +154,13 @@ func main() {
 			Value:   FlexKey,
 			Usage:   DeviceUsageStr,
 			EnvVars: []string{"DCGM_EXPORTER_DEVICES_STR"},
+		},
+		&cli.StringFlag{
+			Name:    CLICustomHostname,
+			Aliases: []string{"u"},
+			Value:   "",
+			Usage:   "Export metrics under a custom hostname.",
+			EnvVars: []string{"DCGM_EXPORTER_CUSTOM_HOSTNAME"},
 		},
 		&cli.BoolFlag{
 			Name:    CLINoHostname,
@@ -420,6 +428,7 @@ func contextToConfig(c *cli.Context) (*dcgmexporter.Config, error) {
 		RemoteHEInfo:        c.String(CLIRemoteHEInfo),
 		GPUDevices:          gOpt,
 		SwitchDevices:       sOpt,
+		CustomHostname:      c.String(CLICustomHostname),
 		NoHostname:          c.Bool(CLINoHostname),
 		UseFakeGpus:         c.Bool(CLIUseFakeGpus),
 		ConfigMapData:       c.String(CLIConfigMapData),

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	google.golang.org/grpc v1.35.0
 	k8s.io/api v0.20.2
 	k8s.io/apimachinery v0.20.2
-	k8s.io/cli-runtime v0.20.2
 	k8s.io/client-go v0.20.2
 	k8s.io/kubelet v0.20.2
 	k8s.io/kubernetes v0.0.0-00010101000000-000000000000

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -30,12 +30,9 @@ func NewDCGMCollector(c []Counter, config *Config, entityType dcgm.Field_Entity_
 		return nil, func() {}, err
 	}
 
-	hostname := ""
-	if config.NoHostname == false {
-		hostname, err = os.Hostname()
-		if err != nil {
-			return nil, func() {}, err
-		}
+	hostname, err := getHostname(config)
+	if err != nil {
+		return nil, func() {}, err
 	}
 
 	var deviceFields = NewDeviceFields(c, entityType)
@@ -60,6 +57,24 @@ func NewDCGMCollector(c []Counter, config *Config, entityType dcgm.Field_Entity_
 	collector.Cleanups = cleanups
 
 	return collector, func() { collector.Cleanup() }, nil
+}
+
+func getHostname(config *Config) (hostname string, err error) {
+	hostname = ""
+
+	if config.NoHostname {
+		return hostname, nil
+	}
+
+	if config.CustomHostname != "" {
+		hostname = config.CustomHostname
+	} else {
+		hostname, err = os.Hostname()
+		if err != nil {
+			return hostname, err
+		}
+	}
+	return hostname, nil
 }
 
 func (c *DCGMCollector) Cleanup() {

--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -141,6 +141,7 @@ func ToDeviceToPod(devicePods *podresourcesapi.ListPodResourcesResponse, sysInfo
 			for _, device := range container.GetDevices() {
 
 				resourceName := device.GetResourceName()
+
 				if resourceName != nvidiaResourceName {
 					// Mig resources appear differently than GPU resources
 					if strings.HasPrefix(resourceName, nvidiaMigResourcePrefix) == false {

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -71,6 +71,7 @@ type Config struct {
 	GPUDevices          DeviceOptions
 	SwitchDevices       DeviceOptions
 	NoHostname          bool
+	CustomHostname      string
 	UseFakeGpus         bool
 	ConfigMapData       string
 	MetricGroups        []dcgm.MetricGroup


### PR DESCRIPTION
- add new parameter to provide custom hostname using CLI flags `--custom-hostname/-u` or environment variable `DCGM_EXPORTER_CUSTOM_HOSTNAME`.

Signed-off-by: Rogerio Peixoto <rcbpeixoto@gmail.com>