### PR TITLE
Update go bindings, remove nvlink status workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ REGISTRY ?= nvidia
 
 DCGM_VERSION   := 3.0.4
 GOLANG_VERSION := 1.17
-VERSION        := 3.1.0
+VERSION        := 3.1.1
 FULL_VERSION   := $(DCGM_VERSION)-$(VERSION)
 OUTPUT         := type=oci,dest=/tmp/dcgm-exporter.tar
 PLATFORMS      := linux/amd64,linux/arm64

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ replace (
 )
 
 require (
-	github.com/NVIDIA/go-dcgm v0.0.0-20221020122955-3241b88a3175
+	github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3
 	github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/NVIDIA/go-dcgm v0.0.0-20220929160432-a45eb235ae9a h1:M5MXgKCaNuYjvZVn
 github.com/NVIDIA/go-dcgm v0.0.0-20220929160432-a45eb235ae9a/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
 github.com/NVIDIA/go-dcgm v0.0.0-20221020122955-3241b88a3175 h1:wQcXli1xIvxM/yBmGQPuuaCTPbrr3hkV+1BPevTY86c=
 github.com/NVIDIA/go-dcgm v0.0.0-20221020122955-3241b88a3175/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
+github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3 h1:qk/qQaBY+918SBhcJsqYwZdDaS3MRtUH2SUX53SC7Cs=
+github.com/NVIDIA/go-dcgm v0.0.0-20221107203308-b6ed78cdc8d3/go.mod h1:atKWXstYFllLarJucBxnt9ivFIPe26Y6S4JQvzqeSr8=
 github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48 h1:JO/JF5CBte9mvATbhoh32swu9erf07ZdLgwFj8u21UQ=
 github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20211102125545-5a2c58442e48/go.mod h1:oKPJa5eOTkWvlT4/Y4D8Nds44Fzmww5HUK+xwO+DwTA=
 github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm v0.0.0-20210325210537-29b4f1784f18/go.mod h1:8qXwltEzU3idjUcVpMOv3FNgxxbDeXZPGMLyc/khWiY=

--- a/pkg/dcgmexporter/pipeline.go
+++ b/pkg/dcgmexporter/pipeline.go
@@ -122,17 +122,6 @@ func (m *MetricsPipeline) Run(out chan string, stop chan interface{}, wg *sync.W
 	}
 }
 
-func GetLinkStatMetricString(c DCGMCollector) string {
-	var linkStr string
-	for _, sw := range c.SysInfo.Switches {
-		for _, link := range sw.NvLinks {
-			linkStr = linkStr + fmt.Sprintf("DCGM_FI_DEV_NSWITCH_NVLINK_STATUS{nvlink=\"link%d\" nvswitch=\"nvswitch%d\",Hostname=\"%s\"} %d\n", link.Index, sw.EntityId, c.Hostname, link.State)
-		}
-	}
-
-	return linkStr
-}
-
 func (m *MetricsPipeline) run() (string, error) {
 	/* Collect GPU Metrics */
 	metrics, err := m.gpuCollector.GetMetrics()
@@ -198,11 +187,6 @@ func (m *MetricsPipeline) run() (string, error) {
 
 			formated = formated + switchFormated
 		}
-
-		/* Add link state output */
-
-		linkStates := GetLinkStatMetricString(*m.linkCollector)
-		formated = formated + linkStates
 	}
 
 	return formated, nil


### PR DESCRIPTION
DCGM_FI_DEV_NVSWITCH_LINK_STATUS can now be used to query nvlink state.