### PR TITLE
Grafana dashboard: fix GPU Power Total

### DIFF
--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -354,8 +354,10 @@
       "targets": [
         {
           "expr": "sum(DCGM_FI_DEV_POWER_USAGE{instance=~\"${instance}\", gpu=~\"${gpu}\"})",
+          "instant": true,
           "interval": "",
           "legendFormat": "",
+          "range": false,
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Make this an "instant" query, that is, calculate the sum over the latest values only (the values listed under "current" in the GPU Power Usage panel to the left)

Previously, it would sum all the values in the range, resulting in an absurdly high value (which could perhaps be scaled to kWh, but is definitly not W any more)

See
https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/?tab=reviews for at least three comments hinting at this problem.