### PR TITLE
fix frame buffer field descriptions default-counters.csv

### DIFF
--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -35,8 +35,8 @@ DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encounte
 # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
 
 # Memory usage
-DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
-DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+DCGM_FI_DEV_FB_FREE, gauge, Frame buffer memory free (in MB).
+DCGM_FI_DEV_FB_USED, gauge, Frame buffer memory used (in MB).
 
 # ECC
 # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.


### PR DESCRIPTION
Bring these in line with [their official docs](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_DEV_FB_FREE)