### PR TITLE
Add ability to change default rollingupdate parameters in helm chart

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -23,6 +23,11 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  {{- with .Values.rollingUpdate }}
+  rollingUpdate:
+    maxUnavailable: {{ .maxUnavailable }}
+    maxSurge: {{ .maxSurge }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "dcgm-exporter.selectorLabels" . | nindent 6 }}
@@ -85,9 +90,9 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
         {{- end }}
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-        args: 
-        {{- range $.Values.arguments }} 
-        - {{ . }} 
+        args:
+        {{- range $.Values.arguments }}
+        - {{ . }}
         {{- end }}
         env:
         - name: "DCGM_EXPORTER_KUBERNETES"

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -51,6 +51,12 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+rollingUpdate:
+  # Specifies maximum number of DaemonSet pods that can be unavailable during the update
+  maxUnavailable: 1
+  # Specifies maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update
+  maxSurge: 0
+
 podAnnotations: {}
 # Using this annotation which is required for prometheus scraping
  # prometheus.io/scrape: "true"


### PR DESCRIPTION
Hello! 
I've added parameters to Daemonset rollingupdate strategy, which will help to faster update DCGM exporter installation inside k8s cluster with a lot of nodes.
Default values are taken from default [Daemonset spec](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec), so it's backward-compatible too.