### PR TITLE
chore: allow override runtimeClassName

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -42,6 +42,9 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName }}
+      {{- end }}
       priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -42,6 +42,8 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 
+runtimeClassName: ""
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Hi,

A tiny PR to be able to force the `runtimeClassName` when I'm not using by default `nvidia` in my CRI config.

Thanks