### PR TITLE
Support for k8s labelled metrics with gpu virtualization or time sharing

### DIFF
--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -177,6 +177,8 @@ func ToDeviceToPod(devicePods *podresourcesapi.ListPodResourcesResponse, sysInfo
 						}
 						giIdentifier := fmt.Sprintf("%s-%s", gpuIndex, gpuInstanceId)
 						deviceToPodMap[giIdentifier] = podInfo
+					} else if strings.Contains(deviceid, "/vgpu") {
+						deviceToPodMap[strings.Split(deviceid, "/vgpu")[0]] = podInfo
 					} else {
 						deviceToPodMap[deviceid] = podInfo
 					}

--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -37,7 +37,8 @@ var (
 
 	connectionTimeout = 10 * time.Second
 
-	gkeMigDeviceIdRegex = regexp.MustCompile(`^nvidia([0-9]+)/gi([0-9]+)$`)
+	gkeMigDeviceIdRegex            = regexp.MustCompile(`^nvidia([0-9]+)/gi([0-9]+)$`)
+	gkeVirtualGPUDeviceIdSeparator = "/vgpu"
 )
 
 func NewPodMapper(c *Config) (*PodMapper, error) {
@@ -177,8 +178,8 @@ func ToDeviceToPod(devicePods *podresourcesapi.ListPodResourcesResponse, sysInfo
 						}
 						giIdentifier := fmt.Sprintf("%s-%s", gpuIndex, gpuInstanceId)
 						deviceToPodMap[giIdentifier] = podInfo
-					} else if strings.Contains(deviceid, "/vgpu") {
-						deviceToPodMap[strings.Split(deviceid, "/vgpu")[0]] = podInfo
+					} else if strings.Contains(deviceid, gkeVirtualGPUDeviceIdSeparator) {
+						deviceToPodMap[strings.Split(deviceid, gkeVirtualGPUDeviceIdSeparator)[0]] = podInfo
 					} else {
 						deviceToPodMap[deviceid] = podInfo
 					}


### PR DESCRIPTION
This PR adds k8s resources metrics like `pod`, `namespace`, and `container` to GPU metrics extracted by DCGM in GPU virtualized environments. Attributing GPU metrics to containers or virtual machines can be tricky when the GPU is shared but here the argument is that these metrics are by virtue of those containers using the GPU. Implementation-wise, the main assumption is that in virtualized environments the `deviceId` used by a container takes the form of `{device-name/uid}/vgpu{number}` and this needs to be mapped to metrics appropriately. The PR has been tested with NVIDIA T4 GPU on a GKE cluster with [time sharing](https://cloud.google.com/kubernetes-engine/docs/concepts/timesharing-gpus) enabled.

Possibly related to 
- https://github.com/NVIDIA/dcgm-exporter/issues/144
- https://github.com/NVIDIA/dcgm-exporter/issues/151
- https://github.com/NVIDIA/dcgm-exporter/issues/63