### PR TITLE
fix: device attribute of time-slicing gpu metrics

### DIFF
--- a/pkg/dcgmexporter/kubernetes.go
+++ b/pkg/dcgmexporter/kubernetes.go
@@ -180,6 +180,9 @@ func ToDeviceToPod(devicePods *podresourcesapi.ListPodResourcesResponse, sysInfo
 						deviceToPodMap[giIdentifier] = podInfo
 					} else if strings.Contains(deviceid, gkeVirtualGPUDeviceIdSeparator) {
 						deviceToPodMap[strings.Split(deviceid, gkeVirtualGPUDeviceIdSeparator)[0]] = podInfo
+					} else if strings.Contains(deviceid, "::") {
+						gpuInstanceId := strings.Split(deviceid, "::")[0]
+						deviceToPodMap[gpuInstanceId] = podInfo
 					} else {
 						deviceToPodMap[deviceid] = podInfo
 					}


### PR DESCRIPTION
This PR addresses https://github.com/NVIDIA/dcgm-exporter/issues/144 and fixes the issue of incorrect `deviceid` being used as the key when `podInfo` is added, in the case when the device is time-slicing GPU. As a result, empty attributes are assigned to the metrics.  

A similar [PR](https://github.com/NVIDIA/dcgm-exporter/pull/185) has already been raised but it only addresses the issue when the cloud provider is GKE. The `deviceid` of time-slicing GPU of AWS takes the form of `{gpuInstanceId}::{number}`. 