### PR TITLE
Support supplying custom pod labels

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -37,6 +37,9 @@ spec:
       labels:
         {{- include "dcgm-exporter.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: "dcgm-exporter"
+      {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- end }}
       {{- if .Values.podAnnotations }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -59,6 +59,8 @@ rollingUpdate:
   # Specifies maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update
   maxSurge: 0
 
+podLabels: {}
+
 podAnnotations: {}
 # Using this annotation which is required for prometheus scraping
  # prometheus.io/scrape: "true"


### PR DESCRIPTION
Hello!

I've added the parameter to allow users to supply additional pod labels, complementing the existing ones. This can help user control over deployments, improve monitoring, and assist in both organization and policy definition based on pod labels.

Please share any concerns or feedback you might have regarding this change!
