### PR TITLE
Update Install Perms in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,9 +39,9 @@ test-main: $(NON_TEST_FILES) $(MAIN_TEST_FILES)
 	go test ./...
 
 install: binary
-	install -m 557 cmd/dcgm-exporter/dcgm-exporter /usr/bin/dcgm-exporter
-	install -m 557 -D ./etc/default-counters.csv /etc/dcgm-exporter/default-counters.csv
-	install -m 557 -D ./etc/dcp-metrics-included.csv /etc/dcgm-exporter/dcp-metrics-included.csv
+	install -m 755 cmd/dcgm-exporter/dcgm-exporter /usr/bin/dcgm-exporter
+	install -m 644 -D ./etc/default-counters.csv /etc/dcgm-exporter/default-counters.csv
+	install -m 644 -D ./etc/dcp-metrics-included.csv /etc/dcgm-exporter/dcp-metrics-included.csv
 
 check-format:
 	test $$(gofmt -l pkg | tee /dev/stderr | wc -l) -eq 0


### PR DESCRIPTION
557 seems like a dangerous permission string for these files, maybe 755 and 644 would be better?