### PR TITLE
Added new command line parameter: replace-blanks-in-model-name

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -46,22 +46,23 @@ const (
 )
 
 const (
-	CLIFieldsFile          = "collectors"
-	CLIAddress             = "address"
-	CLICollectInterval     = "collect-interval"
-	CLIKubernetes          = "kubernetes"
-	CLIKubernetesGPUIDType = "kubernetes-gpu-id-type"
-	CLIUseOldNamespace     = "use-old-namespace"
-	CLIRemoteHEInfo        = "remote-hostengine-info"
-	CLIGPUDevices          = "devices"
-	CLISwitchDevices       = "switch-devices"
-	CLICPUDevices          = "cpu-devices"
-	CLINoHostname          = "no-hostname"
-	CLIUseFakeGPUs         = "fake-gpus"
-	CLIConfigMapData       = "configmap-data"
-	CLIWebSystemdSocket    = "web-systemd-socket"
-	CLIWebConfigFile       = "web-config-file"
-	CLIXIDCountWindowSize  = "xid-count-window-size"
+	CLIFieldsFile               = "collectors"
+	CLIAddress                  = "address"
+	CLICollectInterval          = "collect-interval"
+	CLIKubernetes               = "kubernetes"
+	CLIKubernetesGPUIDType      = "kubernetes-gpu-id-type"
+	CLIUseOldNamespace          = "use-old-namespace"
+	CLIRemoteHEInfo             = "remote-hostengine-info"
+	CLIGPUDevices               = "devices"
+	CLISwitchDevices            = "switch-devices"
+	CLICPUDevices               = "cpu-devices"
+	CLINoHostname               = "no-hostname"
+	CLIUseFakeGPUs              = "fake-gpus"
+	CLIConfigMapData            = "configmap-data"
+	CLIWebSystemdSocket         = "web-systemd-socket"
+	CLIWebConfigFile            = "web-config-file"
+	CLIXIDCountWindowSize       = "xid-count-window-size"
+	CLIReplaceBlanksInModelName = "replace-blanks-in-model-name"
 )
 
 func NewApp(buildVersion ...string) *cli.App {
@@ -181,6 +182,13 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   int((5 * time.Minute).Milliseconds()),
 			Usage:   "Set time window size in milliseconds (ms) for counting active XID errors in DCGM Exporter.",
 			EnvVars: []string{"DCGM_EXPORTER_XID_COUNT_WINDOW_SIZE"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIReplaceBlanksInModelName,
+			Aliases: []string{"rbmn"},
+			Value:   false,
+			Usage:   "Replaces every blank space in the GPU model name with a dash, ensuring a continuous, space-free identifier.",
+			EnvVars: []string{"DCGM_EXPORTER_REPLACE_BLANKS_IN_MODEL_NAME"},
 		},
 	}
 
@@ -399,23 +407,24 @@ func contextToConfig(c *cli.Context) (*dcgmexporter.Config, error) {
 	}
 
 	return &dcgmexporter.Config{
-		CollectorsFile:      c.String(CLIFieldsFile),
-		Address:             c.String(CLIAddress),
-		CollectInterval:     c.Int(CLICollectInterval),
-		Kubernetes:          c.Bool(CLIKubernetes),
-		KubernetesGPUIdType: dcgmexporter.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
-		CollectDCP:          true,
-		UseOldNamespace:     c.Bool(CLIUseOldNamespace),
-		UseRemoteHE:         c.IsSet(CLIRemoteHEInfo),
-		RemoteHEInfo:        c.String(CLIRemoteHEInfo),
-		GPUDevices:          gOpt,
-		SwitchDevices:       sOpt,
-		CPUDevices:          cOpt,
-		NoHostname:          c.Bool(CLINoHostname),
-		UseFakeGPUs:         c.Bool(CLIUseFakeGPUs),
-		ConfigMapData:       c.String(CLIConfigMapData),
-		WebSystemdSocket:    c.Bool(CLIWebSystemdSocket),
-		WebConfigFile:       c.String(CLIWebConfigFile),
-		XIDCountWindowSize:  c.Int(CLIXIDCountWindowSize),
+		CollectorsFile:           c.String(CLIFieldsFile),
+		Address:                  c.String(CLIAddress),
+		CollectInterval:          c.Int(CLICollectInterval),
+		Kubernetes:               c.Bool(CLIKubernetes),
+		KubernetesGPUIdType:      dcgmexporter.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
+		CollectDCP:               true,
+		UseOldNamespace:          c.Bool(CLIUseOldNamespace),
+		UseRemoteHE:              c.IsSet(CLIRemoteHEInfo),
+		RemoteHEInfo:             c.String(CLIRemoteHEInfo),
+		GPUDevices:               gOpt,
+		SwitchDevices:            sOpt,
+		CPUDevices:               cOpt,
+		NoHostname:               c.Bool(CLINoHostname),
+		UseFakeGPUs:              c.Bool(CLIUseFakeGPUs),
+		ConfigMapData:            c.String(CLIConfigMapData),
+		WebSystemdSocket:         c.Bool(CLIWebSystemdSocket),
+		WebConfigFile:            c.String(CLIWebConfigFile),
+		XIDCountWindowSize:       c.Int(CLIXIDCountWindowSize),
+		ReplaceBlanksInModelName: c.Bool(CLIReplaceBlanksInModelName),
 	}, nil
 }

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -60,25 +60,26 @@ type DeviceOptions struct {
 }
 
 type Config struct {
-	CollectorsFile      string
-	Address             string
-	CollectInterval     int
-	Kubernetes          bool
-	KubernetesGPUIdType KubernetesGPUIDType
-	CollectDCP          bool
-	UseOldNamespace     bool
-	UseRemoteHE         bool
-	RemoteHEInfo        string
-	GPUDevices          DeviceOptions
-	SwitchDevices       DeviceOptions
-	CPUDevices          DeviceOptions
-	NoHostname          bool
-	UseFakeGPUs         bool
-	ConfigMapData       string
-	MetricGroups        []dcgm.MetricGroup
-	WebSystemdSocket    bool
-	WebConfigFile       string
-	XIDCountWindowSize  int
+	CollectorsFile           string
+	Address                  string
+	CollectInterval          int
+	Kubernetes               bool
+	KubernetesGPUIdType      KubernetesGPUIDType
+	CollectDCP               bool
+	UseOldNamespace          bool
+	UseRemoteHE              bool
+	RemoteHEInfo             string
+	GPUDevices               DeviceOptions
+	SwitchDevices            DeviceOptions
+	CPUDevices               DeviceOptions
+	NoHostname               bool
+	UseFakeGPUs              bool
+	ConfigMapData            string
+	MetricGroups             []dcgm.MetricGroup
+	WebSystemdSocket         bool
+	WebConfigFile            string
+	XIDCountWindowSize       int
+	ReplaceBlanksInModelName bool
 }
 
 type Transform interface {
@@ -105,12 +106,13 @@ type MetricsPipeline struct {
 }
 
 type DCGMCollector struct {
-	Counters        []Counter
-	DeviceFields    []dcgm.Short
-	Cleanups        []func()
-	UseOldNamespace bool
-	SysInfo         SystemInfo
-	Hostname        string
+	Counters                 []Counter
+	DeviceFields             []dcgm.Short
+	Cleanups                 []func()
+	UseOldNamespace          bool
+	SysInfo                  SystemInfo
+	Hostname                 string
+	ReplaceBlanksInModelName bool
 }
 
 type Counter struct {


### PR DESCRIPTION
**Problem:** [NVIDIA/k8s-device-plugin](https://github.com/NVIDIA/k8s-device-plugin) produces K8S labels `gpu.product` values with blank spaces replaced with dash. 
The dcgm-exporter reads the GPU model name from DCGM, doesn't perform blank space replacement with dashes, and returns raw values as the DCGM library returns. This leads to a mismatch between the GPU product name on the Kubernetes node label and the one in the DCGM metrics. For example:

The label has the value: "nvidia.com/gpu.product" = "NVIDIA-T400-4GB" on a node label, but in DCGM metric, it is called: "NVIDIA T400 4GB".

**Solution**

Added the new "replace-blanks-in-model-name" parameter, that asks DCGM-Exporter to replace every blank space in the GPU model name with a dash, ensuring a continuous, space-free identifier.

*Test Scenarios*

Backward compatibility:

1. Run dcgm-exporter:

```
go run cmd/dcgm-exporter/main.go -f ./etc/default-counters.csv
```

2. Wait for 30 seconds;

3. Make HTTP request: 
```
 curl -v http://localhost:9400/metrics
```

Expected result: 

You should see the GPU model name with blank spaces, for example:

```
# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).
# TYPE DCGM_FI_DEV_MEM_CLOCK gauge
DCGM_FI_DEV_MEM_CLOCK{gpu="0",UUID="GPU-b9f9e81b-bee7-34bc-af17-132ef6592740",device="nvidia0",modelName="NVIDIA T400 4GB",Hostname="workstation",DCGM_FI_DRIVER_VERSION="545.29.02"} 405
```


New functionality, when we replace blank spaces with dash:

1. Run dcgm-exporter:

```
go run cmd/dcgm-exporter/main.go -f ./etc/default-counters.csv -rbmn
```

2. Wait for 30 seconds;

3. Make HTTP request: 
```
 curl -v http://localhost:9400/metrics
```

Expected result: 

You should see the GPU model name with blank spaces, replaced by dash, for example:

```
# HELP DCGM_FI_DEV_MEM_CLOCK Memory clock frequency (in MHz).
# TYPE DCGM_FI_DEV_MEM_CLOCK gauge
DCGM_FI_DEV_MEM_CLOCK{gpu="0",UUID="GPU-b9f9e81b-bee7-34bc-af17-132ef6592740",device="nvidia0",modelName="NVIDIA-T400-4GB",Hostname="workstation",DCGM_FI_DRIVER_VERSION="545.29.02"} 405
```