### PR TITLE
Make error message styling consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,31 +15,35 @@ vendor/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+## Directory-based project format:
+.idea/
+# if you decide to remove above rule then ignore the following:
+
 # User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
+#.idea/**/workspace.xml
+#.idea/**/tasks.xml
+#.idea/**/usage.statistics.xml
+#.idea/**/dictionaries
+#.idea/**/shelf
 
 # AWS User-specific
-.idea/**/aws.xml
+#.idea/**/aws.xml
 
 # Generated files
-.idea/**/contentModel.xml
+#.idea/**/contentModel.xml
 
 # Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
+#.idea/**/dataSources/
+#.idea/**/dataSources.ids
+#.idea/**/dataSources.local.xml
+#.idea/**/sqlDataSources.xml
+#.idea/**/dynamic.xml
+#.idea/**/uiDesigner.xml
+#.idea/**/dbnavigator.xml
 
 # Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
+#.idea/**/gradle.xml
+#.idea/**/libraries
 
 # Gradle and Maven with auto-import
 # When using Gradle or Maven with auto-import, you should exclude module files,

--- a/internal/pkg/nvmlprovider/provider.go
+++ b/internal/pkg/nvmlprovider/provider.go
@@ -43,7 +43,7 @@ func GetMIGDeviceInfoByID(uuid string) (*MIGDeviceInfo, error) {
 		ret := nvml.Init()
 		if ret != nvml.SUCCESS {
 			err = errors.New(nvml.ErrorString(ret))
-			logrus.Error("Can not init NVML library")
+			logrus.Error("Can not init NVML library.")
 		}
 	})
 	if err != nil {
@@ -88,22 +88,22 @@ func GetMIGDeviceInfoByID(uuid string) (*MIGDeviceInfo, error) {
 
 	tokens := strings.SplitN(uuid, "-", 2)
 	if len(tokens) != 2 || tokens[0] != "MIG" {
-		return nil, fmt.Errorf("Unable to parse UUID as MIG device")
+		return nil, fmt.Errorf("unable to parse UUID '%s' as MIG device", uuid)
 	}
 
 	tokens = strings.SplitN(tokens[1], "/", 3)
 	if len(tokens) != 3 || !strings.HasPrefix(tokens[0], "GPU-") {
-		return nil, fmt.Errorf("Unable to parse UUID as MIG device")
+		return nil, fmt.Errorf("unable to parse UUID '%s' as MIG device", uuid)
 	}
 
 	gi, err := strconv.Atoi(tokens[1])
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse UUID as MIG device")
+		return nil, fmt.Errorf("unable to parse UUID '%s' as MIG device", uuid)
 	}
 
 	ci, err := strconv.Atoi(tokens[2])
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse UUID as MIG device")
+		return nil, fmt.Errorf("unable to parse UUID '%s' as MIG device", uuid)
 	}
 
 	return &MIGDeviceInfo{

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -236,7 +236,7 @@ restart:
 	defer func() {
 		if r := recover(); r != nil {
 			logrus.WithField(dcgmexporter.LoggerStackTrace, string(debug.Stack())).Error("Encountered a failure.")
-			err = fmt.Errorf("Encountered a failure: %v", r)
+			err = fmt.Errorf("encountered a failure; err: %v", r)
 		}
 	}()
 
@@ -361,14 +361,15 @@ func parseDeviceOptions(devices string) (dcgmexporter.DeviceOptions, error) {
 	letterAndRange := strings.Split(devices, ":")
 	count := len(letterAndRange)
 	if count > 2 {
-		return dOpt, fmt.Errorf("Invalid ranged device option '%s': there can only be one specified range", devices)
+		return dOpt, fmt.Errorf("invalid ranged device option '%s'; err: there can only be one specified range",
+			devices)
 	}
 
 	letter := letterAndRange[0]
 	if letter == FlexKey {
 		dOpt.Flex = true
 		if count > 1 {
-			return dOpt, fmt.Errorf("No range can be specified with the flex option 'f'")
+			return dOpt, fmt.Errorf("no range can be specified with the flex option 'f'")
 		}
 	} else if letter == MajorKey || letter == MinorKey {
 		var indices []int
@@ -381,7 +382,7 @@ func parseDeviceOptions(devices string) (dcgmexporter.DeviceOptions, error) {
 				rangeTokens := strings.Split(numberOrRange, "-")
 				rangeTokenCount := len(rangeTokens)
 				if rangeTokenCount > 2 {
-					return dOpt, fmt.Errorf("A range can only be '<number>-<number>', but found '%s'", numberOrRange)
+					return dOpt, fmt.Errorf("range can only be '<number>-<number>', but found '%s'", numberOrRange)
 				} else if rangeTokenCount == 1 {
 					number, err := strconv.Atoi(rangeTokens[0])
 					if err != nil {
@@ -412,7 +413,7 @@ func parseDeviceOptions(devices string) (dcgmexporter.DeviceOptions, error) {
 			dOpt.MinorRange = indices
 		}
 	} else {
-		return dOpt, fmt.Errorf("The only valid options preceding ':<range>' are 'g' or 'i', but found '%s'", letter)
+		return dOpt, fmt.Errorf("valid options preceding ':<range>' are 'g' or 'i', but found '%s'", letter)
 	}
 
 	return dOpt, nil

--- a/pkg/dcgmexporter/const.go
+++ b/pkg/dcgmexporter/const.go
@@ -44,7 +44,7 @@ func (d DCGMExporterMetric) String() string {
 func IdentifyMetricType(s string) (DCGMExporterMetric, error) {
 	mv, ok := DCGMFields[s]
 	if !ok {
-		return mv, fmt.Errorf("Unknown DCGMExporterMetric field '%s'", s)
+		return mv, fmt.Errorf("unknown DCGMExporterMetric field '%s'", s)
 	}
 	return mv, nil
 }

--- a/pkg/dcgmexporter/const_test.go
+++ b/pkg/dcgmexporter/const_test.go
@@ -56,7 +56,7 @@ func TestIdentifyMetricType(t *testing.T) {
 				assert.NoError(t, err, "Expected metrics to be found.")
 				assert.Equal(t, output, tt.output, "Invalid output")
 			} else {
-				assert.Errorf(t, err, "Expected metrics to be not found")
+				assert.Errorf(t, err, "Expected metrics to be not found.")
 			}
 		})
 	}

--- a/pkg/dcgmexporter/dcgm.go
+++ b/pkg/dcgmexporter/dcgm.go
@@ -33,7 +33,7 @@ func NewGroup() (dcgm.GroupHandle, func(), error) {
 	return group, func() {
 		err := dcgm.DestroyGroup(group)
 		if err != nil {
-			logrus.WithError(err).Warn("Cannot destroy field group")
+			logrus.WithError(err).Warn("Cannot destroy field group.")
 		}
 	}, nil
 }
@@ -65,12 +65,14 @@ func NewFieldGroup(deviceFields []dcgm.Short) (dcgm.FieldHandle, func(), error) 
 	return fieldGroup, func() {
 		err := dcgm.FieldGroupDestroy(fieldGroup)
 		if err != nil {
-			logrus.WithError(err).Warn("Cannot destroy field group")
+			logrus.WithError(err).Warn("Cannot destroy field group.")
 		}
 	}, nil
 }
 
-func WatchFieldGroup(group dcgm.GroupHandle, field dcgm.FieldHandle, updateFreq int64, maxKeepAge float64, maxKeepSamples int32) error {
+func WatchFieldGroup(
+	group dcgm.GroupHandle, field dcgm.FieldHandle, updateFreq int64, maxKeepAge float64, maxKeepSamples int32,
+) error {
 	err := dcgm.WatchFieldsWithGroupEx(field, group, updateFreq, maxKeepAge, maxKeepSamples)
 	if err != nil {
 		return err

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -27,11 +27,12 @@ import (
 
 type DCGMCollectorConstructor func([]Counter, *Config, string, dcgm.Field_Entity_Group) (*DCGMCollector, func(), error)
 
-func NewDCGMCollector(c []Counter, config *Config, hostname string, entityType dcgm.Field_Entity_Group) (*DCGMCollector, func(), error) {
+func NewDCGMCollector(c []Counter, config *Config, hostname string, entityType dcgm.Field_Entity_Group) (*DCGMCollector,
+	func(), error) {
 	var deviceFields = NewDeviceFields(c, entityType)
 
 	if !ShouldMonitorDeviceType(deviceFields, entityType) {
-		return nil, func() {}, fmt.Errorf("No fields to watch for device type: %d", entityType)
+		return nil, func() {}, fmt.Errorf("no fields to watch for device type '%d'", entityType)
 	}
 
 	sysInfo, err := GetSystemInfo(config, entityType)
@@ -59,7 +60,8 @@ func NewDCGMCollector(c []Counter, config *Config, hostname string, entityType d
 }
 
 func GetSystemInfo(config *Config, entityType dcgm.Field_Entity_Group) (*SystemInfo, error) {
-	sysInfo, err := InitializeSystemInfo(config.GPUDevices, config.SwitchDevices, config.CPUDevices, config.UseFakeGPUs, entityType)
+	sysInfo, err := InitializeSystemInfo(config.GPUDevices, config.SwitchDevices, config.CPUDevices, config.UseFakeGPUs,
+		entityType)
 	if err != nil {
 		return nil, err
 	}
@@ -150,11 +152,13 @@ func FindCounterField(c []Counter, fieldId uint) (Counter, error) {
 		}
 	}
 
-	return c[0], fmt.Errorf("Could not find corresponding counter")
+	return c[0], fmt.Errorf("could not find counter corresponding to field ID '%d'", fieldId)
 }
 
-func ToSwitchMetric(metrics MetricsByCounter,
-	values []dcgm.FieldValue_v1, c []Counter, mi MonitoringInfo, useOld bool, hostname string) {
+func ToSwitchMetric(
+	metrics MetricsByCounter,
+	values []dcgm.FieldValue_v1, c []Counter, mi MonitoringInfo, useOld bool, hostname string,
+) {
 	labels := map[string]string{}
 
 	for _, val := range values {
@@ -196,8 +200,10 @@ func ToSwitchMetric(metrics MetricsByCounter,
 	}
 }
 
-func ToCPUMetric(metrics MetricsByCounter,
-	values []dcgm.FieldValue_v1, c []Counter, mi MonitoringInfo, useOld bool, hostname string) {
+func ToCPUMetric(
+	metrics MetricsByCounter,
+	values []dcgm.FieldValue_v1, c []Counter, mi MonitoringInfo, useOld bool, hostname string,
+) {
 	var labels = map[string]string{}
 
 	for _, val := range values {

--- a/pkg/dcgmexporter/kubernetes_test.go
+++ b/pkg/dcgmexporter/kubernetes_test.go
@@ -24,14 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
-	"github.com/NVIDIA/dcgm-exporter/internal/pkg/testutils"
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	podresourcesapi "k8s.io/kubernetes/pkg/kubelet/apis/podresources/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/util"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/testutils"
 )
 
 var tmpDir string
@@ -111,7 +112,7 @@ func StartMockServer(t *testing.T, server *grpc.Server, socket string) func() {
 		case <-stopped:
 			return
 		case <-time.After(1 * time.Second):
-			t.Fatal("Failed waiting for gRPC server to stop")
+			t.Fatal("Failed waiting for gRPC server to stop.")
 		}
 	}
 }
@@ -138,7 +139,9 @@ func NewPodResourcesMockServer(used []string) *PodResourcesMockServer {
 	}
 }
 
-func (s *PodResourcesMockServer) List(ctx context.Context, req *podresourcesapi.ListPodResourcesRequest) (*podresourcesapi.ListPodResourcesResponse, error) {
+func (s *PodResourcesMockServer) List(
+	ctx context.Context, req *podresourcesapi.ListPodResourcesRequest,
+) (*podresourcesapi.ListPodResourcesResponse, error) {
 	podResources := make([]*podresourcesapi.PodResources, len(s.gpus))
 
 	for i, gpu := range s.gpus {

--- a/pkg/dcgmexporter/pipeline_test.go
+++ b/pkg/dcgmexporter/pipeline_test.go
@@ -49,12 +49,15 @@ func TestRun(t *testing.T) {
 	t.Logf("Pipeline result is:\n%v", out)
 }
 
-func testNewDCGMCollector(counter *int, enabledCollector map[dcgm.Field_Entity_Group]struct{}) DCGMCollectorConstructor {
-	return func(c []Counter, config *Config, hostname string, entityType dcgm.Field_Entity_Group) (*DCGMCollector, func(), error) {
+func testNewDCGMCollector(
+	counter *int, enabledCollector map[dcgm.Field_Entity_Group]struct{},
+) DCGMCollectorConstructor {
+	return func(c []Counter, config *Config, hostname string, entityType dcgm.Field_Entity_Group) (*DCGMCollector,
+		func(), error) {
 		// should always create GPU Collector
 		if entityType != dcgm.FE_GPU {
 			if _, ok := enabledCollector[entityType]; !ok {
-				return nil, func() {}, fmt.Errorf("%s collector should not be created", entityType)
+				return nil, func() {}, fmt.Errorf("collector '%s' should not be created", entityType)
 			}
 		}
 
@@ -79,50 +82,52 @@ func TestCountPipelineCleanup(t *testing.T) {
 	for _, c := range []struct {
 		name             string
 		enabledCollector map[dcgm.Field_Entity_Group]struct{}
-	}{{
-		name:             "only_gpu",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{},
-	}, {
-		name: "gpu_switch",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_SWITCH: struct{}{},
+	}{
+		{
+			name:             "only_gpu",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{},
+		}, {
+			name: "gpu_switch",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_SWITCH: struct{}{},
+			},
+		}, {
+			name: "gpu_link",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_LINK: struct{}{},
+			},
+		}, {
+			name: "gpu_cpu",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_CPU: struct{}{},
+			},
+		}, {
+			name: "gpu_core",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_CPU_CORE: struct{}{},
+			},
+		}, {
+			name: "gpu_switch_link",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_SWITCH: struct{}{},
+				dcgm.FE_LINK:   struct{}{},
+			},
+		}, {
+			name: "gpu_cpu_core",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_CPU:      struct{}{},
+				dcgm.FE_CPU_CORE: struct{}{},
+			},
+		}, {
+			name: "all",
+			enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
+				dcgm.FE_SWITCH:   struct{}{},
+				dcgm.FE_LINK:     struct{}{},
+				dcgm.FE_CPU:      struct{}{},
+				dcgm.FE_CPU_CORE: struct{}{},
+			},
 		},
-	}, {
-		name: "gpu_link",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_LINK: struct{}{},
-		},
-	}, {
-		name: "gpu_cpu",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_CPU: struct{}{},
-		},
-	}, {
-		name: "gpu_core",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_CPU_CORE: struct{}{},
-		},
-	}, {
-		name: "gpu_switch_link",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_SWITCH: struct{}{},
-			dcgm.FE_LINK:   struct{}{},
-		},
-	}, {
-		name: "gpu_cpu_core",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_CPU:      struct{}{},
-			dcgm.FE_CPU_CORE: struct{}{},
-		},
-	}, {
-		name: "all",
-		enabledCollector: map[dcgm.Field_Entity_Group]struct{}{
-			dcgm.FE_SWITCH:   struct{}{},
-			dcgm.FE_LINK:     struct{}{},
-			dcgm.FE_CPU:      struct{}{},
-			dcgm.FE_CPU_CORE: struct{}{},
-		},
-	}} {
+	} {
 		cleanupCounter := 0
 
 		config := &Config{
@@ -136,7 +141,8 @@ func TestCountPipelineCleanup(t *testing.T) {
 			logrus.Fatal(err)
 		}
 
-		_, cleanup, err := NewMetricsPipeline(config, counters, "", testNewDCGMCollector(&cleanupCounter, c.enabledCollector))
+		_, cleanup, err := NewMetricsPipeline(config, counters, "",
+			testNewDCGMCollector(&cleanupCounter, c.enabledCollector))
 		require.NoError(t, err, "case: %s failed", c.name)
 
 		cleanup()

--- a/pkg/dcgmexporter/server.go
+++ b/pkg/dcgmexporter/server.go
@@ -58,8 +58,8 @@ func NewMetricsServer(c *Config, metrics chan string, registry *Registry) (*Metr
 			</body>
 			</html>`))
 		if err != nil {
-			logrus.WithError(err).Error("Failed to write response")
-			http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			logrus.WithError(err).Error("Failed to write response.")
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
 			return
 		}
 	})
@@ -81,7 +81,7 @@ func (s *MetricsServer) Run(stop chan interface{}, wg *sync.WaitGroup) {
 		defer httpwg.Done()
 		logrus.Info("Starting webserver")
 		if err := web.ListenAndServe(s.server, s.webConfig, logger); err != nil && err != http.ErrServerClosed {
-			logrus.WithError(err).Fatal("Failed to Listen and Server HTTP server")
+			logrus.WithError(err).Fatal("Failed to Listen and Server HTTP server.")
 		}
 	}()
 
@@ -100,11 +100,11 @@ func (s *MetricsServer) Run(stop chan interface{}, wg *sync.WaitGroup) {
 
 	<-stop
 	if err := s.server.Shutdown(context.Background()); err != nil {
-		logrus.WithError(err).Fatal("Failed to shutdown HTTP server")
+		logrus.WithError(err).Fatal("Failed to shutdown HTTP server.")
 	}
 
 	if err := WaitWithTimeout(&httpwg, 3*time.Second); err != nil {
-		logrus.WithError(err).Fatal("Failed waiting for HTTP server to shutdown")
+		logrus.WithError(err).Fatal("Failed waiting for HTTP server to shutdown.")
 	}
 }
 
@@ -113,19 +113,19 @@ func (s *MetricsServer) Metrics(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	_, err := w.Write([]byte(s.getMetrics()))
 	if err != nil {
-		logrus.WithError(err).Error("Failed to write response")
-		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		logrus.WithError(err).Error("Failed to write response.")
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
 		return
 	}
 	xidMetrics, err := s.registry.Gather()
 	if err != nil {
-		logrus.WithError(err).Error("Failed to write response")
-		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		logrus.WithError(err).Error("Failed to write response.")
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
 		return
 	}
 	err = encodeXIDMetrics(w, xidMetrics)
 	if err != nil {
-		http.Error(w, "Failed to write response", http.StatusInternalServerError)
+		http.Error(w, "failed to write response", http.StatusInternalServerError)
 		return
 	}
 }
@@ -136,16 +136,16 @@ func (s *MetricsServer) Health(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err := w.Write([]byte("KO"))
 		if err != nil {
-			logrus.WithError(err).Error("Failed to write response")
-			http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			logrus.WithError(err).Error("Failed to write response.")
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
 		}
 	} else {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("OK"))
 		if err != nil {
-			logrus.WithError(err).Error("Failed to write response")
-			http.Error(w, "Failed to write response", http.StatusInternalServerError)
+			logrus.WithError(err).Error("Failed to write response.")
+			http.Error(w, "failed to write response", http.StatusInternalServerError)
 		}
 	}
 }

--- a/pkg/dcgmexporter/system_info_test.go
+++ b/pkg/dcgmexporter/system_info_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var fakeProfileName string = "2fake.4gb"
+var fakeProfileName = "2fake.4gb"
 
 func SpoofSwitchSystemInfo() SystemInfo {
 	var sysInfo SystemInfo
@@ -521,10 +521,10 @@ func TestIsCoreWatched(t *testing.T) {
 
 func TestSetMigProfileNames(t *testing.T) {
 	tests := []struct {
-		name        string
-		sysInfo     SystemInfo
-		values      []dcgm.FieldValue_v2
-		valid       bool
+		name    string
+		sysInfo SystemInfo
+		values  []dcgm.FieldValue_v2
+		valid   bool
 	}{
 		{
 			name: "MIG profile found",
@@ -652,7 +652,7 @@ func TestSetMigProfileNames(t *testing.T) {
 					EntityId:    1,
 					FieldType:   dcgm.DCGM_FT_BINARY,
 					StringValue: &fakeProfileName,
-					Value: [4096]byte{'1','2','3'},
+					Value:       [4096]byte{'1', '2', '3'},
 				},
 			},
 			valid: true,

--- a/pkg/dcgmexporter/utils.go
+++ b/pkg/dcgmexporter/utils.go
@@ -32,6 +32,6 @@ func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	case <-c:
 		return nil
 	case <-time.After(timeout):
-		return fmt.Errorf("Timeout waiting for WaitGroup")
+		return fmt.Errorf("timeout waiting for WaitGroup")
 	}
 }

--- a/pkg/dcgmexporter/xid_collector.go
+++ b/pkg/dcgmexporter/xid_collector.go
@@ -208,9 +208,10 @@ func NewXIDCollector(config *Config, counters []Counter, hostname string) (Colle
 
 	var deviceFields = NewDeviceFields(labelsCounters, dcgm.FE_GPU)
 
-	cleanups, err := SetupDcgmFieldsWatch([]dcgm.Short{dcgm.DCGM_FI_DEV_XID_ERRORS}, *sysInfo, int64(config.CollectInterval)*1000)
+	cleanups, err := SetupDcgmFieldsWatch([]dcgm.Short{dcgm.DCGM_FI_DEV_XID_ERRORS}, *sysInfo,
+		int64(config.CollectInterval)*1000)
 	if err != nil {
-		logrus.Fatal("Failed to watch metrics: ", err)
+		logrus.Fatalf("Failed to watch metrics; err: %v", err)
 	}
 
 	counter := counters[slices.IndexFunc(counters, func(c Counter) bool {


### PR DESCRIPTION
The purpose of this PR is to achieve consistent error message styling. Styling follows the following conventions:

1. Error strings should not be capitalized (unless beginning with an exported name, a proper noun or an acronym) and should not end with punctuation. 
```
err := fmt.Errorf("something bad happened")
```

2. Error message is separated from the main message string using `;` seperator.
```
err := fmt.Errorf("something bad happened; err: %w", err)
```

3. Use of `%w` in place of `%v` to make it available to `errors.Is` and `errors.As` when supporting custom errors in future.

**NOTE:** There were 2-3 instances where it was not possible to applying the correct styling without changing existing logic a bit. So please pay special attention to those changes.