### PR TITLE
DCGM_FI_EXP_CLOCK_THROTTLE_REASONS_COUNT was renamed to the DCGM_EXP_CLOCK_EVENTS_COUNT

### DIFF
--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -5,7 +5,7 @@
 # Clocks
 DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
 DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
-# DCGM_FI_EXP_CLOCK_THROTTLE_REASONS_COUNT, gauge, Count of clock throttle reasons within the user-specified time window (see clock-throttle-reasons-count-window-size param).
+# DCGM_EXP_CLOCK_EVENTS_COUNT, gauge, Count of clock events within the user-specified time window (see clock-events-count-window-size param).
 
 # Temperature
 DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -48,25 +48,25 @@ const (
 )
 
 const (
-	CLIFieldsFile                          = "collectors"
-	CLIAddress                             = "address"
-	CLICollectInterval                     = "collect-interval"
-	CLIKubernetes                          = "kubernetes"
-	CLIKubernetesGPUIDType                 = "kubernetes-gpu-id-type"
-	CLIUseOldNamespace                     = "use-old-namespace"
-	CLIRemoteHEInfo                        = "remote-hostengine-info"
-	CLIGPUDevices                          = "devices"
-	CLISwitchDevices                       = "switch-devices"
-	CLICPUDevices                          = "cpu-devices"
-	CLINoHostname                          = "no-hostname"
-	CLIUseFakeGPUs                         = "fake-gpus"
-	CLIConfigMapData                       = "configmap-data"
-	CLIWebSystemdSocket                    = "web-systemd-socket"
-	CLIWebConfigFile                       = "web-config-file"
-	CLIXIDCountWindowSize                  = "xid-count-window-size"
-	CLIReplaceBlanksInModelName            = "replace-blanks-in-model-name"
-	CLIDebugMode                           = "debug"
-	CLIClockThrottleReasonsCountWindowSize = "clock-throttle-reasons-count-window-size"
+	CLIFieldsFile                 = "collectors"
+	CLIAddress                    = "address"
+	CLICollectInterval            = "collect-interval"
+	CLIKubernetes                 = "kubernetes"
+	CLIKubernetesGPUIDType        = "kubernetes-gpu-id-type"
+	CLIUseOldNamespace            = "use-old-namespace"
+	CLIRemoteHEInfo               = "remote-hostengine-info"
+	CLIGPUDevices                 = "devices"
+	CLISwitchDevices              = "switch-devices"
+	CLICPUDevices                 = "cpu-devices"
+	CLINoHostname                 = "no-hostname"
+	CLIUseFakeGPUs                = "fake-gpus"
+	CLIConfigMapData              = "configmap-data"
+	CLIWebSystemdSocket           = "web-systemd-socket"
+	CLIWebConfigFile              = "web-config-file"
+	CLIXIDCountWindowSize         = "xid-count-window-size"
+	CLIReplaceBlanksInModelName   = "replace-blanks-in-model-name"
+	CLIDebugMode                  = "debug"
+	CLIClockEventsCountWindowSize = "clock-events-count-window-size"
 )
 
 func NewApp(buildVersion ...string) *cli.App {
@@ -201,10 +201,10 @@ func NewApp(buildVersion ...string) *cli.App {
 			EnvVars: []string{"DCGM_EXPORTER_DEBUG"},
 		},
 		&cli.IntFlag{
-			Name:    CLIClockThrottleReasonsCountWindowSize,
+			Name:    CLIClockEventsCountWindowSize,
 			Value:   int((5 * time.Minute).Milliseconds()),
-			Usage:   "Set time window size in milliseconds (ms) for counting active XID errors in DCGM Exporter.",
-			EnvVars: []string{"DCGM_EXPORTER_XID_COUNT_WINDOW_SIZE"},
+			Usage:   "Set time window size in milliseconds (ms) for counting clock events in DCGM Exporter.",
+			EnvVars: []string{"DCGM_EXPORTER_CLOCK_EVENTS_COUNT_WINDOW_SIZE"},
 		},
 	}
 
@@ -362,12 +362,12 @@ restart:
 		logrus.Infof("%s collector initialized", dcgmexporter.DCGMXIDErrorsCount.String())
 	}
 
-	if dcgmexporter.IsDCGMExpClockThrottleReasonsEnabledCount(cs.ExporterCounters) {
+	if dcgmexporter.IsDCGMExpClockEventsCountEnabled(cs.ExporterCounters) {
 		item, exists := fieldEntityGroupTypeSystemInfo.Get(dcgm.FE_GPU)
 		if !exists {
-			logrus.Fatalf("%s collector cannot be initialized", dcgmexporter.DCGMClockThrottleReasonsCount.String())
+			logrus.Fatalf("%s collector cannot be initialized", dcgmexporter.DCGMClockEventsCount.String())
 		}
-		clocksThrottleReasonsCollector, err := dcgmexporter.NewClocksThrottleReasonsCollector(
+		clocksThrottleReasonsCollector, err := dcgmexporter.NewClockEventsCollector(
 			cs.ExporterCounters, hostname, config, item)
 		if err != nil {
 			logrus.Fatal(err)
@@ -375,7 +375,7 @@ restart:
 
 		cRegistry.Register(clocksThrottleReasonsCollector)
 
-		logrus.Infof("%s collector initialized", dcgmexporter.DCGMClockThrottleReasonsCount.String())
+		logrus.Infof("%s collector initialized", dcgmexporter.DCGMClockEventsCount.String())
 	}
 
 	defer func() {
@@ -493,26 +493,26 @@ func contextToConfig(c *cli.Context) (*dcgmexporter.Config, error) {
 	}
 
 	return &dcgmexporter.Config{
-		CollectorsFile:                      c.String(CLIFieldsFile),
-		Address:                             c.String(CLIAddress),
-		CollectInterval:                     c.Int(CLICollectInterval),
-		Kubernetes:                          c.Bool(CLIKubernetes),
-		KubernetesGPUIdType:                 dcgmexporter.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
-		CollectDCP:                          true,
-		UseOldNamespace:                     c.Bool(CLIUseOldNamespace),
-		UseRemoteHE:                         c.IsSet(CLIRemoteHEInfo),
-		RemoteHEInfo:                        c.String(CLIRemoteHEInfo),
-		GPUDevices:                          gOpt,
-		SwitchDevices:                       sOpt,
-		CPUDevices:                          cOpt,
-		NoHostname:                          c.Bool(CLINoHostname),
-		UseFakeGPUs:                         c.Bool(CLIUseFakeGPUs),
-		ConfigMapData:                       c.String(CLIConfigMapData),
-		WebSystemdSocket:                    c.Bool(CLIWebSystemdSocket),
-		WebConfigFile:                       c.String(CLIWebConfigFile),
-		XIDCountWindowSize:                  c.Int(CLIXIDCountWindowSize),
-		ReplaceBlanksInModelName:            c.Bool(CLIReplaceBlanksInModelName),
-		Debug:                               c.Bool(CLIDebugMode),
-		ClockThrottleReasonsCountWindowSize: c.Int(CLIClockThrottleReasonsCountWindowSize),
+		CollectorsFile:             c.String(CLIFieldsFile),
+		Address:                    c.String(CLIAddress),
+		CollectInterval:            c.Int(CLICollectInterval),
+		Kubernetes:                 c.Bool(CLIKubernetes),
+		KubernetesGPUIdType:        dcgmexporter.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
+		CollectDCP:                 true,
+		UseOldNamespace:            c.Bool(CLIUseOldNamespace),
+		UseRemoteHE:                c.IsSet(CLIRemoteHEInfo),
+		RemoteHEInfo:               c.String(CLIRemoteHEInfo),
+		GPUDevices:                 gOpt,
+		SwitchDevices:              sOpt,
+		CPUDevices:                 cOpt,
+		NoHostname:                 c.Bool(CLINoHostname),
+		UseFakeGPUs:                c.Bool(CLIUseFakeGPUs),
+		ConfigMapData:              c.String(CLIConfigMapData),
+		WebSystemdSocket:           c.Bool(CLIWebSystemdSocket),
+		WebConfigFile:              c.String(CLIWebConfigFile),
+		XIDCountWindowSize:         c.Int(CLIXIDCountWindowSize),
+		ReplaceBlanksInModelName:   c.Bool(CLIReplaceBlanksInModelName),
+		Debug:                      c.Bool(CLIDebugMode),
+		ClockEventsCountWindowSize: c.Int(CLIClockEventsCountWindowSize),
 	}, nil
 }

--- a/pkg/dcgmexporter/config.go
+++ b/pkg/dcgmexporter/config.go
@@ -31,26 +31,26 @@ type DeviceOptions struct {
 }
 
 type Config struct {
-	CollectorsFile                      string
-	Address                             string
-	CollectInterval                     int
-	Kubernetes                          bool
-	KubernetesGPUIdType                 KubernetesGPUIDType
-	CollectDCP                          bool
-	UseOldNamespace                     bool
-	UseRemoteHE                         bool
-	RemoteHEInfo                        string
-	GPUDevices                          DeviceOptions
-	SwitchDevices                       DeviceOptions
-	CPUDevices                          DeviceOptions
-	NoHostname                          bool
-	UseFakeGPUs                         bool
-	ConfigMapData                       string
-	MetricGroups                        []dcgm.MetricGroup
-	WebSystemdSocket                    bool
-	WebConfigFile                       string
-	XIDCountWindowSize                  int
-	ReplaceBlanksInModelName            bool
-	Debug                               bool
-	ClockThrottleReasonsCountWindowSize int
+	CollectorsFile             string
+	Address                    string
+	CollectInterval            int
+	Kubernetes                 bool
+	KubernetesGPUIdType        KubernetesGPUIDType
+	CollectDCP                 bool
+	UseOldNamespace            bool
+	UseRemoteHE                bool
+	RemoteHEInfo               string
+	GPUDevices                 DeviceOptions
+	SwitchDevices              DeviceOptions
+	CPUDevices                 DeviceOptions
+	NoHostname                 bool
+	UseFakeGPUs                bool
+	ConfigMapData              string
+	MetricGroups               []dcgm.MetricGroup
+	WebSystemdSocket           bool
+	WebConfigFile              string
+	XIDCountWindowSize         int
+	ReplaceBlanksInModelName   bool
+	Debug                      bool
+	ClockEventsCountWindowSize int
 }

--- a/pkg/dcgmexporter/exporter_metrics.go
+++ b/pkg/dcgmexporter/exporter_metrics.go
@@ -19,16 +19,16 @@ package dcgmexporter
 import "fmt"
 
 const (
-	dcgmExpClockThrottleReasonsCount = "DCGM_FI_EXP_CLOCK_THROTTLE_REASONS_COUNT"
-	dcgmExpXIDErrorsCount            = "DCGM_EXP_XID_ERRORS_COUNT"
+	dcgmExpClockEventsCount = "DCGM_EXP_CLOCK_EVENTS_COUNT"
+	dcgmExpXIDErrorsCount   = "DCGM_EXP_XID_ERRORS_COUNT"
 )
 
 type ExporterCounter uint16
 
 const (
-	DCGMFIUnknown                 ExporterCounter = 0
-	DCGMXIDErrorsCount            ExporterCounter = iota + 9000
-	DCGMClockThrottleReasonsCount ExporterCounter = iota
+	DCGMFIUnknown        ExporterCounter = 0
+	DCGMXIDErrorsCount   ExporterCounter = iota + 9000
+	DCGMClockEventsCount ExporterCounter = iota
 )
 
 // String method to convert the enum value to a string
@@ -36,8 +36,8 @@ func (enm ExporterCounter) String() string {
 	switch enm {
 	case DCGMXIDErrorsCount:
 		return dcgmExpXIDErrorsCount
-	case DCGMClockThrottleReasonsCount:
-		return dcgmExpClockThrottleReasonsCount
+	case DCGMClockEventsCount:
+		return dcgmExpClockEventsCount
 	default:
 		return "DCGM_FI_UNKNOWN"
 	}
@@ -45,9 +45,9 @@ func (enm ExporterCounter) String() string {
 
 // DCGMFields maps DCGMExporterMetric String to enum
 var DCGMFields = map[string]ExporterCounter{
-	DCGMXIDErrorsCount.String():            DCGMXIDErrorsCount,
-	DCGMClockThrottleReasonsCount.String(): DCGMClockThrottleReasonsCount,
-	DCGMFIUnknown.String():                 DCGMFIUnknown,
+	DCGMXIDErrorsCount.String():   DCGMXIDErrorsCount,
+	DCGMClockEventsCount.String(): DCGMClockEventsCount,
+	DCGMFIUnknown.String():        DCGMFIUnknown,
 }
 
 func IdentifyMetricType(s string) (ExporterCounter, error) {


### PR DESCRIPTION
The new metric DCGM_FI_EXP_CLOCK_THROTTLE_REASONS_COUNT was renamed to the DCGM_EXP_CLOCK_EVENTS_COUNT. 

Metric output:

```
# TYPE DCGM_EXP_CLOCK_EVENTS_COUNT gauge
DCGM_EXP_CLOCK_EVENTS_COUNT{gpu="0",UUID="GPU-b9f9e81b-bee7-34bc-af17-132ef6592740",device="nvidia0",modelName="NVIDIA T400 4GB",Hostname="home",DCGM_FI_DRIVER_VERSION="545.29.02",clock_event="gpu_idle",window_size_in_ms="300000"} 2
DCGM_EXP_CLOCK_EVENTS_COUNT{gpu="0",UUID="GPU-b9f9e81b-bee7-34bc-af17-132ef6592740",device="nvidia0",modelName="NVIDIA T400 4GB",Hostname="home",DCGM_FI_DRIVER_VERSION="545.29.02",clock_event="sw_thermal",window_size_in_ms="300000"} 1
DCGM_EXP_CLOCK_EVENTS_COUNT{gpu="0",UUID="GPU-b9f9e81b-bee7-34bc-af17-132ef6592740",device="nvidia0",modelName="NVIDIA T400 4GB",Hostname="home",DCGM_FI_DRIVER_VERSION="545.29.02",clock_event="hw_thermal",window_size_in_ms="300000"} 1
```