### PR TITLE
Added ability to enable DCGM library log output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,9 @@
             "args": [
                 "-f",
                 "./etc/default-counters.csv",
-                "--debug"
+                "--debug",
+                "--enable-dcgm-log",
+                "--dcgm-log-level=INFO"
             ]
         }
     ]

--- a/Makefile
+++ b/Makefile
@@ -94,4 +94,3 @@ validate-modules:
 tools: ## Install required tools and utilities
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 	go install github.com/axw/gocov/gocov@latest
-	

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.0-2
 	github.com/avast/retry-go/v4 v4.5.1
 	github.com/bits-and-blooms/bitset v1.13.0
+	github.com/go-kit/log v0.2.1
 	github.com/gorilla/mux v1.8.1
 	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.47.0
@@ -31,7 +32,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/internal/pkg/logging/logger_adapter.go
+++ b/internal/pkg/logging/logger_adapter.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"fmt"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/sirupsen/logrus"
+)
+
+// LogrusAdapter is an adapter that allows logrus Logger to be used as a go-kit/log Logger.
+type LogrusAdapter struct {
+	Logger *logrus.Logger
+}
+
+// NewLogrusAdapter creates a new LogrusAdapter with the provided logrus.Logger.
+func NewLogrusAdapter(logger *logrus.Logger) log.Logger {
+	return &LogrusAdapter{
+		Logger: logger,
+	}
+}
+
+// Log implements the go-kit/log Logger interface.
+func (la *LogrusAdapter) Log(keyvals ...interface{}) error {
+	// keyvals is a slice of interfaces, that represents a key-value pairs.
+	if len(keyvals)%2 != 0 {
+		keyvals = append(keyvals, "MISSING")
+	}
+
+	fields := logrus.Fields{}
+	for i := 0; i < len(keyvals); i += 2 {
+		key, ok := keyvals[i].(string)
+		if !ok {
+			// If the key is not la string, use la default key
+			key = "missing_key"
+		}
+		fields[key] = keyvals[i+1]
+	}
+
+	// The go-kit/log uses msg field to keep log message, we don't want to use message as field in the logrus.
+	msg, exists := fields["msg"]
+	if exists {
+		delete(fields, "msg")
+	}
+
+	// The go-kit/log uses level fields to keep log level. We need to convert this field into logrus value.
+	lvl, exists := fields["level"]
+	if !exists {
+		fields["level"] = level.InfoValue()
+	}
+	delete(fields, "level")
+	parsedLvl, err := logrus.ParseLevel(fmt.Sprint(lvl))
+	if err != nil {
+		parsedLvl = logrus.InfoLevel
+	}
+
+	la.Logger.WithFields(fields).Log(parsedLvl, msg)
+
+	return nil
+}

--- a/internal/pkg/logging/logger_adapter_test.go
+++ b/internal/pkg/logging/logger_adapter_test.go
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logging
+
+import (
+	"github.com/go-kit/log/level"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestLogrusAdapter_Log(t *testing.T) {
+	type testCase struct {
+		name    string
+		keyvals []interface{}
+		assert  func(*testing.T, *logrus.Entry)
+	}
+
+	//"msg", "Listening on", "address"
+	testCases := []testCase{
+		{
+			name: "Success",
+			keyvals: []interface{}{
+				"level",
+				level.InfoValue,
+				"msg",
+				"Listening on",
+				"address",
+				"127.0.0.0.1:8080",
+			},
+			assert: func(t *testing.T, entry *logrus.Entry) {
+				t.Helper()
+				require.NotNil(t, entry)
+				assert.Equal(t, "Listening on", entry.Message)
+				require.Contains(t, entry.Data, "address")
+				assert.Equal(t, "127.0.0.0.1:8080", entry.Data["address"])
+			},
+		},
+		{
+			name: "When no Level",
+			keyvals: []interface{}{
+				"msg",
+				"Listening on",
+				"address",
+				"127.0.0.0.1:8080",
+			},
+			assert: func(t *testing.T, entry *logrus.Entry) {
+				t.Helper()
+				require.NotNil(t, entry)
+				assert.Equal(t, "Listening on", entry.Message)
+				require.Contains(t, entry.Data, "address")
+				assert.Equal(t, "127.0.0.0.1:8080", entry.Data["address"])
+			},
+		},
+		{
+			name: "When key is not string",
+			keyvals: []interface{}{
+				"msg",
+				"Listening on",
+				42,
+				"127.0.0.0.1:8080",
+			},
+			assert: func(t *testing.T, entry *logrus.Entry) {
+				t.Helper()
+				require.NotNil(t, entry)
+				assert.Equal(t, "Listening on", entry.Message)
+				require.Contains(t, entry.Data, "missing_key")
+				assert.Equal(t, "127.0.0.0.1:8080", entry.Data["missing_key"])
+			},
+		},
+		{
+			name: "When value is missing",
+			keyvals: []interface{}{
+				"msg",
+				"Listening on",
+				"address",
+			},
+			assert: func(t *testing.T, entry *logrus.Entry) {
+				t.Helper()
+				require.NotNil(t, entry)
+				assert.Equal(t, "Listening on", entry.Message)
+				require.Contains(t, entry.Data, "address")
+				assert.Equal(t, "MISSING", entry.Data["address"])
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			logrusLogger, logHook := test.NewNullLogger()
+			logger := NewLogrusAdapter(logrusLogger)
+			err := logger.Log(tc.keyvals...)
+			require.NoError(t, err)
+			tc.assert(t, logHook.LastEntry())
+		})
+	}
+}

--- a/pkg/dcgmexporter/config.go
+++ b/pkg/dcgmexporter/config.go
@@ -53,4 +53,6 @@ type Config struct {
 	ReplaceBlanksInModelName   bool
 	Debug                      bool
 	ClockEventsCountWindowSize int
+	EnableDCGMLog              bool
+	DCGMLogLevel               string
 }

--- a/pkg/dcgmexporter/const.go
+++ b/pkg/dcgmexporter/const.go
@@ -31,3 +31,23 @@ const (
 const (
 	windowSizeInMSLabel = "window_size_in_ms"
 )
+
+// DCGMDbgLvl is a DCGM library debug level.
+const (
+	DCGMDbgLvlNone  = "NONE"
+	DCGMDbgLvlFatal = "FATAL"
+	DCGMDbgLvlError = "ERROR"
+	DCGMDbgLvlWarn  = "WARN"
+	DCGMDbgLvlInfo  = "INFO"
+	DCGMDbgLvlDebug = "DEBUG"
+	DCGMDbgLvlVerb  = "VERB"
+)
+
+var DCGMDbgLvlValues = []string{DCGMDbgLvlNone,
+	DCGMDbgLvlFatal,
+	DCGMDbgLvlError,
+	DCGMDbgLvlWarn,
+	DCGMDbgLvlInfo,
+	DCGMDbgLvlDebug,
+	DCGMDbgLvlVerb,
+}

--- a/pkg/dcgmexporter/server.go
+++ b/pkg/dcgmexporter/server.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/logging"
 	"github.com/gorilla/mux"
-	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/sirupsen/logrus"
 )
@@ -72,8 +72,8 @@ func NewMetricsServer(c *Config, metrics chan string, registry *Registry) (*Metr
 
 func (s *MetricsServer) Run(stop chan interface{}, wg *sync.WaitGroup) {
 	defer wg.Done()
-	promlogConfig := &promlog.Config{}
-	logger := promlog.New(promlogConfig)
+	// Wrap the logrus logger with the LogrusAdapter
+	logger := logging.NewLogrusAdapter(logrus.StandardLogger())
 
 	var httpwg sync.WaitGroup
 	httpwg.Add(1)

--- a/pkg/stdout/capture.go
+++ b/pkg/stdout/capture.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdout
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Capture go and C stdout and stderr and writes to logrus.StandardLogger
+func Capture(ctx context.Context, inner func() error) error {
+	stdout, err := syscall.Dup(syscall.Stdout)
+	if err != nil {
+		return err
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Dup2(int(w.Fd()), syscall.Stdout)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		ierr := syscall.Close(syscall.Stdout)
+		if ierr != nil {
+			err = ierr
+		}
+
+		ierr = syscall.Dup2(stdout, syscall.Stdout)
+		if ierr != nil {
+			err = ierr
+		}
+	}()
+
+	scanner := bufio.NewScanner(r)
+	go func() {
+		for scanner.Scan() {
+			if ctx.Err() != nil {
+				return
+			}
+			logEntry := scanner.Text()
+			parsedLogEntry := parseOutputEntry(logEntry)
+			if parsedLogEntry.IsRawString {
+				_, err := logrus.StandardLogger().Out.Write([]byte(parsedLogEntry.Message + "\n"))
+				if err != nil {
+					return
+				}
+				continue
+			}
+			logrus.WithField("dcgm_level", parsedLogEntry.Level).Info(parsedLogEntry.Message)
+		}
+	}()
+
+	// Call function here
+	return inner()
+}

--- a/pkg/stdout/capture_test.go
+++ b/pkg/stdout/capture_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdout
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCapture(t *testing.T) {
+	type testCase struct {
+		name       string
+		logMessage string
+		assert     func(t *testing.T, str string)
+	}
+
+	testCases := []testCase{
+		{
+			name:       "function writes an arbitrary string into /dev/stdout",
+			logMessage: "hello from dcgm",
+			assert: func(t *testing.T, str string) {
+				assert.Equal(t, "hello from dcgm", strings.TrimSpace(str))
+			},
+		},
+		{
+			name:       "function writes an DCGM log entry string into /dev/stdout",
+			logMessage: "2024-02-07 18:01:05.641 INFO  [517155:517155] Linux 4.15.0-180-generic [{anonymous}::StartEmbeddedV2]",
+			assert: func(t *testing.T, str string) {
+				assert.Contains(t, strings.TrimSpace(str), "Linux 4.15.0-180-generic")
+			},
+		},
+		{
+			name:       "function writes an DCGM log entry string with a valid date only",
+			logMessage: "2024-02-07 18:01:05.641",
+			assert: func(t *testing.T, str string) {
+				assert.Equal(t, "2024-02-07 18:01:05.641", strings.TrimSpace(str))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+
+			buf := &bytes.Buffer{}
+			logrus.SetOutput(buf)
+
+			err := Capture(ctx, func() error {
+				fmt.Println(tc.logMessage)
+				return nil
+			})
+
+			assert.NoError(t, err)
+			time.Sleep(1 * time.Millisecond)
+			tc.assert(t, buf.String())
+			cancel()
+		})
+	}
+}
+
+func TestCaptureWithCGO(t *testing.T) {
+	testCaptureWithCGO(t)
+}

--- a/pkg/stdout/capture_test_wrapper.go
+++ b/pkg/stdout/capture_test_wrapper.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdout
+
+/*
+#include <stdio.h>
+void printBoom() {
+	printf("Boom\n");
+	fflush(stdout);
+}
+*/
+import "C"
+import (
+	"bytes"
+	"context"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testCaptureWithCGO(t *testing.T) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	buf := &bytes.Buffer{}
+	logrus.SetOutput(buf)
+
+	err := Capture(ctx, func() error {
+		C.printBoom()
+		return nil
+	})
+	assert.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, "Boom", strings.TrimSpace(buf.String()))
+
+	cancel()
+}

--- a/pkg/stdout/stdoutprocessor.go
+++ b/pkg/stdout/stdoutprocessor.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stdout
+
+import (
+	"strings"
+	"time"
+)
+
+// outputEntry represents the structured form of the parsed log entry.
+type outputEntry struct {
+	Timestamp   time.Time
+	Level       string
+	Message     string
+	IsRawString bool
+}
+
+// parseOutputEntry takes a log entry string and returns a structured outputEntry object.
+func parseOutputEntry(entry string) outputEntry {
+	// Split the entry by spaces, taking care to not split the function call and its arguments.
+	fields := strings.Fields(entry)
+
+	if len(fields) > 2 {
+		// Parse the timestamp.
+		timestamp, err := time.Parse("2006-01-02 15:04:05.000", fields[0]+" "+fields[1])
+		if err != nil {
+			return outputEntry{
+				Message:     entry,
+				IsRawString: true,
+			}
+		}
+
+		level := fields[2]
+
+		// Reconstruct the string from the fourth field onwards to deal with function calls and arguments.
+		remainder := strings.Join(fields[4:], " ")
+
+		return outputEntry{
+			Timestamp: timestamp,
+			Level:     level,
+			Message:   remainder,
+		}
+	}
+
+	return outputEntry{
+		Message:     entry,
+		IsRawString: true,
+	}
+}


### PR DESCRIPTION
Users are now able to use the "--enable-dcgm-log" and "--dcgm-log-level=[NONE,FATAL,ERROR,WARN,INFO,DEBUG,VERB]" flags to enable DCGM library log output into the dcgm-exporter logs. 

**Important:** The default value for the "--dcgm-log-level" is "NONE". To see DCGM logs, you must set at least the `INFO` log level.

Here is an example of the DCGM log output:

```
time="2024-03-01T14:24:35-06:00" level=info msg="version:3.3.3;arch:x86_64;buildtype:Release;buildid:11;builddate:2024-01-18;commit:c3aed64480553cd5ba1a32d165c7967936446631;branch:rel_dcgm_3_3;buildplatform:Linux 4.15.0-180-generic #189-Ubuntu SMP Wed May 18 14:13:57 UTC 2022 x86_64;;crc:39ff792f5514bdc5af56ce313a8fa90e [/workspaces/dcgm-rel_dcgm_3_3-postmerge/dcgmlib/src/DcgmApi.cpp:5012] [{anonymous}::StartEmbeddedV2]" dcgm_level=INFO
time="2024-03-01T14:24:35-06:00" level=info msg="Signal 12 is already handled. Nothing to do. [/workspaces/dcgm-rel_dcgm_3_3-postmerge/common/DcgmThread/DcgmThread.cpp:394] [DcgmThread::InstallSignalHandler]" dcgm_level=INFO
time="2024-03-01T14:24:35-06:00" level=info msg="Parsed driver string is 5452902, IsR450OrNewer: 1, IsR520OrNewer: 1 [/workspaces/dcgm-rel_dcgm_3_3-postmerge/dcgmlib/src/DcgmCacheManager.cpp:2592] [DcgmCacheManager::ReadAndCacheDriverVersions]" dcgm_level=INFO
time="2024-03-01T14:24:35-06:00" level=info msg="Detected 0 NVLinks for GPU 0 [/workspaces/dcgm-rel_dcgm_3_3-postmerge/dcgmlib/src/DcgmCacheManager.cpp:1263] [DcgmCacheManager::InitializeNvLinkCount]" dcgm_level=INFO
time="2024-03-01T14:24:35-06:00" level=info msg="Got 0 excluded GPUs [/workspaces/dcgm-rel_dcgm_3_3-postmerge/dcgmlib/src/DcgmCacheManager.cpp:1087] [DcgmCacheManager::ReadAndCacheGpuExclusionList]" dcgm_level=INFO
```