### PR TITLE
Fix power calculation

### DIFF
--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -304,7 +304,7 @@
       "options": {
         "fieldOptions": {
           "calcs": [
-            "sum"
+            "lastNotNull"
           ],
           "defaults": {
             "color": {


### PR DESCRIPTION
Using the calculation of `sum` for the power gauge results in summing the gauge over time, rather than reflecting the average amount for the time window. Swap it for `lastNotNull`.