### PR TITLE
Issue 102 - Allow setting runtimeClassName

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -37,13 +37,21 @@ arguments: ["-f", "/etc/dcgm-exporter/dcp-metrics-included.csv"]
 # the watched exporter fields.
 # Example arguments: ["-m", "default:exporter-metrics-config-map"]
 
+# Image pull secrets for container images
 imagePullSecrets: []
+
+# Overrides the chart's name
 nameOverride: ""
+
+# Overrides the chart's computed fullname
 fullnameOverride: ""
+
+# Overrides the deployment namespace
 namespaceOverride: ""
 
+# Defines the runtime class that will be used by the pod
 runtimeClassName: ""
-
+# Defines serviceAccount names for components.
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
@@ -59,16 +67,20 @@ rollingUpdate:
   # Specifies maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update
   maxSurge: 0
 
+# Labels to be added to dcgm-exporter pods
 podLabels: {}
 
+# Annotations to be added to dcgm-exporter pods
 podAnnotations: {}
 # Using this annotation which is required for prometheus scraping
  # prometheus.io/scrape: "true"
  # prometheus.io/port: "9400"
 
+# The SecurityContext for the dcgm-exporter pods
 podSecurityContext: {}
   # fsGroup: 2000
 
+# The SecurityContext for the dcgm-exporter containers
 securityContext:
   runAsNonRoot: false
   runAsUser: 0
@@ -76,7 +88,9 @@ securityContext:
      add: ["SYS_ADMIN"]
   # readOnlyRootFilesystem: true
 
+# Defines the dcgm-exporter service
 service:
+  # When enabled, the helm chart will create service
   enable: true
   type: ClusterIP
   port: 9400
@@ -84,6 +98,7 @@ service:
   # Annotations to add to the service
   annotations: {}
 
+# Allows to control pod resources
 resources: {}
   # limits:
   #   cpu: 100m
@@ -137,4 +152,5 @@ extraEnv: []
 #- name: EXTRA_VAR
 #  value: "TheStringValue"
 
+# Path to the kubelet socket for /pod-resources
 kubeletPath: "/var/lib/kubelet/pod-resources"


### PR DESCRIPTION
No changes in the values.yaml, except comments added for better documentation. 

Test steps:

1. Install K3S
```
curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE="644" sh -s -
```

2. View available run times:

```
kubectl get runtimeclasses
```

You should expect to see: 

```
NAME                  HANDLER               AGE
crun                  crun                  4h
lunatic               lunatic               4h
nvidia-experimental   nvidia-experimental   4h
slight                slight                4h
spin                  spin                  4h
wasmedge              wasmedge              4h
wasmer                wasmer                4h
wasmtime              wasmtime              4h
wws                   wws                   4h
nvidia                nvidia                4h
```

3. Deploy the dcgm exporter 

```
helm install --generate-name ./deployment/ --set runtimeClassName=nvidia --set serviceMonitor.enabled=false
```

4. Check pod configuration:

```
kubectl get pods deployment-1710791202-dcgm-exporter-jrgc7 -o yaml
```

You should see: `runtimeClassName: nvidia` and that the pod is up and running.