### PR TITLE
E2E tests can be run with default-counters.csv

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,16 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Go: Launch e2e",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/tests/e2e",
+            "args": ["-kubeconfig","~/.kube/config", "-chart","./../../deployment/","-image-repository","nvidia/dcgm-exporter","-arguments","{-f=/etc/dcgm-exporter/dcp-metrics-included.csv,--enable-dcgm-log=true,--dcgm-log-level=ERROR}"],
+            "env": {},
+            "buildFlags": "-tags=e2e"
+        },
+        {
             "name": "Run Debug",
             "type": "go",
             "request": "launch",

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -25,9 +25,25 @@ e2e-test:
 		echo "[ERR] KUBECONFIG is missing, must be set"; \
 		exit 1; \
 	fi
-	$(GO_CMD) test --tags=e2e -v . -args \
+	$(GO_CMD) test -failfast --tags=e2e -v . -args \
 		-kubeconfig=$(KUBECONFIG) \
 		-chart="$(CHART)" \
 		-namespace=$(NAMESPACE) \
 		-image-repository=$(IMAGE_REPOSITORY) \
 		-image-tag=$(IMAGE_TAG)
+
+
+.PHONY: e2e-test-no-profiling
+e2e-test-no-profiling:
+	@if [ -z ${KUBECONFIG} ]; then \
+		echo "[ERR] KUBECONFIG is missing, must be set"; \
+		exit 1; \
+	fi
+	$(GO_CMD) test -failfast --tags=e2e -v . -args \
+		-kubeconfig=$(KUBECONFIG) \
+		-chart="$(CHART)" \
+		-namespace=$(NAMESPACE) \
+		-image-repository=$(IMAGE_REPOSITORY) \
+		-image-tag=$(IMAGE_TAG) \
+		-arguments="{-f=/etc/dcgm-exporter/default-counters.csv}"
+

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -19,31 +19,27 @@ IMAGE_REPOSITORY ?= "nvcr.io/nvidia/k8s/dcgm-exporter"
 IMAGE_TAG ?= "3.3.5-3.4.0-ubuntu22.04"
 KUBECONFIG ?= "~/.kube/config"
 
-.PHONY: e2e-test
-e2e-test:
+define TEST_CMD
 	@if [ -z ${KUBECONFIG} ]; then \
 		echo "[ERR] KUBECONFIG is missing, must be set"; \
 		exit 1; \
 	fi
-	$(GO_CMD) test -failfast --tags=e2e -v . -args \
+	$(GO_CMD) test --tags=e2e -v . \
+		-args \
 		-kubeconfig=$(KUBECONFIG) \
 		-chart="$(CHART)" \
 		-namespace=$(NAMESPACE) \
 		-image-repository=$(IMAGE_REPOSITORY) \
 		-image-tag=$(IMAGE_TAG)
+endef
+
+.PHONY: e2e-test
+e2e-test:
+	@$(TEST_CMD)
 
 
 .PHONY: e2e-test-no-profiling
 e2e-test-no-profiling:
-	@if [ -z ${KUBECONFIG} ]; then \
-		echo "[ERR] KUBECONFIG is missing, must be set"; \
-		exit 1; \
-	fi
-	$(GO_CMD) test -failfast --tags=e2e -v . -args \
-		-kubeconfig=$(KUBECONFIG) \
-		-chart="$(CHART)" \
-		-namespace=$(NAMESPACE) \
-		-image-repository=$(IMAGE_REPOSITORY) \
-		-image-tag=$(IMAGE_TAG) \
+	@$(TEST_CMD) \
 		-arguments="{-f=/etc/dcgm-exporter/default-counters.csv}"
 

--- a/tests/e2e/internal/framework/kube.go
+++ b/tests/e2e/internal/framework/kube.go
@@ -92,6 +92,12 @@ func (c *KubeClient) CheckPodCondition(ctx context.Context,
 		}
 	}
 
+	for _, c := range pod.Status.ContainerStatuses {
+		if c.State.Waiting != nil && c.State.Waiting.Reason == "CrashLoopBackOff" {
+			return false, fmt.Errorf("pod %s in namespace %s is in CrashLoopBackOff", pod.Name, pod.Namespace)
+		}
+	}
+
 	return false, nil
 }
 

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -74,7 +74,7 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 	os.Exit(m.Run())
 }
-git
+
 // TestRunSuite will be run by the 'go test' command
 func TestRunSuite(t *testing.T) {
 	suite.Run(t, NewSuite())

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -66,6 +66,11 @@ func TestMain(m *testing.M) {
 		"",
 		"DCGM-exporter image tag to use")
 
+	flag.StringVar(&suiteCfg.arguments,
+		"arguments",
+		"",
+		"DCGM-exporter command line")
+
 	flag.Parse()
 	os.Exit(m.Run())
 }

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -69,12 +69,12 @@ func TestMain(m *testing.M) {
 	flag.StringVar(&suiteCfg.arguments,
 		"arguments",
 		"",
-		"DCGM-exporter command line")
+		`DCGM-exporter command line parameters. Example: -arguments={-f=/etc/dcgm-exporter/default-counters.csv}`)
 
 	flag.Parse()
 	os.Exit(m.Run())
 }
-
+git
 // TestRunSuite will be run by the 'go test' command
 func TestRunSuite(t *testing.T) {
 	suite.Run(t, NewSuite())


### PR DESCRIPTION
The E2E tests with default configuration use the helm release, which deploys the dcgm-exporter with the `dcp-metrics-included.csv` configuration. This configuration includes profiling metrics available on the datacenter-grade GPU.  
For example, if you use `NVIDIA T400`, the e2e test fails because the dcgm-exporter can not be initiated because of unsupported hardware. 

To provide the ability to run e2e tests on low-grade GPUs compatible with DCGM, I added the ability to specify custom arguments in the e2e scripts. As a result:
1. The default `make e2e` command runs e2e tests with enabled profiling metrics.
2. If the developer wants to run the e2e tests without profiling metrics, they can do the following:

```
cd tests/e2e
make e2e-test-no-profiling
```
