### PR TITLE
Chore: Added golangci configuration and formater to the makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,19 @@
+linters:
+  enable:
+    - contextcheck
+    - gocritic
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unused
+    - gofumpt
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/NVIDIA/dcgm-exporter
+

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ test-coverage:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./... --timeout $(GOLANGCILINT_TIMEOUT)  --new-from-rev=HEAD~1
+	golangci-lint run ./... --timeout $(GOLANGCILINT_TIMEOUT)  --new-from-rev=HEAD~1 --verbose
 
 .PHONY: validate-modules
 validate-modules:

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ include hack/VERSION
 
 MKDIR    ?= mkdir
 REGISTRY ?= nvidia
+GOLANGCILINT_TIMEOUT ?= 10m
 
 DCGM_VERSION   := $(NEW_DCGM_VERSION)
 GOLANG_VERSION := 1.21.5
@@ -83,7 +84,7 @@ test-coverage:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run ./... --timeout $(GOLANGCILINT_TIMEOUT)  --new-from-rev=HEAD~1
 
 .PHONY: validate-modules
 validate-modules:
@@ -98,6 +99,10 @@ tools: ## Install required tools and utilities
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
 	go install github.com/axw/gocov/gocov@latest
 	go install golang.org/x/tools/cmd/goimports@latest
+	go install mvdan.cc/gofumpt@latest
+
+fmt:
+	find . -name '*.go' | xargs gofumpt -l -w
 
 goimports:
 	go list -f {{.Dir}} $(MODULE)/... \

--- a/pkg/dcgmexporter/kubernetes_test.go
+++ b/pkg/dcgmexporter/kubernetes_test.go
@@ -162,7 +162,6 @@ func (s *PodResourcesMockServer) List(
 	return &podresourcesapi.ListPodResourcesResponse{
 		PodResources: podResources,
 	}, nil
-
 }
 
 func TestProcessPodMapper_WithD_Different_Format_Of_DeviceID(t *testing.T) {
@@ -273,7 +272,8 @@ func TestProcessPodMapper_WithD_Different_Format_Of_DeviceID(t *testing.T) {
 
 				podMapper, err := NewPodMapper(&Config{
 					KubernetesGPUIdType:       tc.KubernetesGPUIDType,
-					PodResourcesKubeletSocket: socketPath})
+					PodResourcesKubeletSocket: socketPath,
+				})
 				require.NoError(t, err)
 				require.NotNil(t, podMapper)
 				metrics := MetricsByCounter{}


### PR DESCRIPTION
- We need to have the ability to control golangci-lint execution timeout.
- Added explicit golangci-lint configuration.
- The golangci-lint now enforces rules only in a new code. 
- Formated the file that was in the past not formatted.