### PR TITLE
The value of the DCGM_FI_DEV_XID_ERRORS field is always printed twice

### DIFF
--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/testutils"
+	"github.com/NVIDIA/dcgm-exporter/pkg/dcgmexporter"
+)
+
+func Test_getFieldEntityGroupTypeSystemInfo(t *testing.T) {
+	config := &dcgmexporter.Config{
+		GPUDevices:    dcgmexporter.DeviceOptions{},
+		SwitchDevices: dcgmexporter.DeviceOptions{},
+		CPUDevices:    dcgmexporter.DeviceOptions{},
+		UseFakeGPUs:   true,
+	}
+
+	tests := []struct {
+		name       string
+		counterSet *dcgmexporter.CounterSet
+		assertion  func(*testing.T, *dcgmexporter.FieldEntityGroupTypeSystemInfo)
+	}{
+		{
+			name: "When DCGM_FI_DEV_XID_ERRORS and DCGM_EXP_XID_ERRORS_COUNT enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				DCGMCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   230,
+						FieldName: "DCGM_FI_DEV_XID_ERRORS",
+						PromType:  "gauge",
+						Help:      "Value of the last XID error encountered.",
+					},
+				},
+				ExporterCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   9001,
+						FieldName: "DCGM_EXP_XID_ERRORS_COUNT",
+						PromType:  "gauge",
+						Help:      "Count of XID Errors within user-specified time window (see xid-count-window-size param).",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(230), values[0].FieldID)
+			},
+		},
+		{
+			name: "When DCGM_FI_DEV_XID_ERRORS enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				DCGMCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   230,
+						FieldName: "DCGM_FI_DEV_XID_ERRORS",
+						PromType:  "gauge",
+						Help:      "Value of the last XID error encountered.",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(230), values[0].FieldID)
+			},
+		},
+		{
+			name: "When DCGM_EXP_XID_ERRORS_COUNT enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				ExporterCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   9001,
+						FieldName: "DCGM_EXP_XID_ERRORS_COUNT",
+						PromType:  "gauge",
+						Help:      "Count of XID Errors within user-specified time window (see xid-count-window-size param).",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(230), values[0].FieldID)
+			},
+		},
+		{
+			name:       "When no counters",
+			counterSet: &dcgmexporter.CounterSet{},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 0)
+			},
+		},
+		{
+			name: "When DCGM_FI_DEV_CLOCK_THROTTLE_REASON and DCGM_EXP_CLOCK_EVENTS_COUNT enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				DCGMCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   112,
+						FieldName: "DCGM_FI_DEV_CLOCK_THROTTLE_REASON",
+						PromType:  "gauge",
+					},
+				},
+				ExporterCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   9002,
+						FieldName: "DCGM_EXP_CLOCK_EVENTS_COUNT",
+						PromType:  "gauge",
+						Help:      "Count of clock events within the user-specified time window (see clock-events-count-window-size param).",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(112), values[0].FieldID)
+			},
+		},
+		{
+			name: "When DCGM_FI_DEV_CLOCK_THROTTLE_REASON enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				DCGMCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   112,
+						FieldName: "DCGM_FI_DEV_CLOCK_THROTTLE_REASON",
+						PromType:  "gauge",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(112), values[0].FieldID)
+			},
+		},
+		{
+			name: "When DCGM_EXP_CLOCK_EVENTS_COUNT enabled",
+			counterSet: &dcgmexporter.CounterSet{
+				ExporterCounters: []dcgmexporter.Counter{
+					{
+						FieldID:   9002,
+						FieldName: "DCGM_EXP_CLOCK_EVENTS_COUNT",
+						PromType:  "gauge",
+						Help:      "Count of clock events within the user-specified time window (see clock-events-count-window-size param).",
+					},
+				},
+			},
+			assertion: func(t *testing.T, got *dcgmexporter.FieldEntityGroupTypeSystemInfo) {
+				require.NotNil(t, got)
+				values := testutils.GetStructPrivateFieldValue[[]dcgmexporter.Counter](t, got, "counters")
+				require.Len(t, values, 1)
+				assert.Equal(t, dcgm.Short(112), values[0].FieldID)
+			},
+		},
+	}
+
+	cleanupDCGM := initDCGM(config)
+	defer cleanupDCGM()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getFieldEntityGroupTypeSystemInfo(tt.counterSet, config)
+			if tt.assertion == nil {
+				t.Skip(tt.name)
+			}
+			tt.assertion(t, got)
+		})
+	}
+}

--- a/pkg/dcgmexporter/exporter_metrics.go
+++ b/pkg/dcgmexporter/exporter_metrics.go
@@ -28,7 +28,7 @@ type ExporterCounter uint16
 const (
 	DCGMFIUnknown        ExporterCounter = 0
 	DCGMXIDErrorsCount   ExporterCounter = iota + 9000
-	DCGMClockEventsCount ExporterCounter = iota
+	DCGMClockEventsCount ExporterCounter = iota + 9000
 )
 
 // String method to convert the enum value to a string


### PR DESCRIPTION
 The DCGM_FI_DEV_XID_ERRORS field value is always printed twice.

Steps to reproduce:

1. Run DCGM-Exporter. 
2. Collect and check metrics output.
```
curl localhost:9400/metrics
```

Expected:
```
# HELP DCGM_FI_DEV_XID_ERRORS Value of the last XID error encountered.
# TYPE DCGM_FI_DEV_XID_ERRORS gauge
DCGM_FI_DEV_XID_ERRORS{gpu="0",UUID="GPU-aee734e0-1a3d-2715-f7e1-4d9d89dc56f2",device="nvidia0",modelName="NVIDIA A100 80GB PCIe",GPU_I_PROFILE="2g.20gb",GPU_I_ID="3",Hostname="4u4g-0018",DCGM_FI_DRIVER_VERSION="555.23"} 0
```

Actual:
```
# HELP DCGM_FI_DEV_XID_ERRORS Value of the last XID error encountered.
# TYPE DCGM_FI_DEV_XID_ERRORS gauge
DCGM_FI_DEV_XID_ERRORS{gpu="0",UUID="GPU-aee734e0-1a3d-2715-f7e1-4d9d89dc56f2",device="nvidia0",modelName="NVIDIA A100 80GB PCIe",GPU_I_PROFILE="2g.20gb",GPU_I_ID="3",Hostname="4u4g-0018",DCGM_FI_DRIVER_VERSION="555.23"} 0
DCGM_FI_DEV_XID_ERRORS{gpu="0",UUID="GPU-aee734e0-1a3d-2715-f7e1-4d9d89dc56f2",device="nvidia0",modelName="NVIDIA A100 80GB PCIe",GPU_I_PROFILE="2g.20gb",GPU_I_ID="3",Hostname="4u4g-0018",DCGM_FI_DRIVER_VERSION="555.23"} 0
```
