### PR TITLE
feat: add pci_bus_id label for metrics

### DIFF
--- a/pkg/dcgmexporter/expcollector.go
+++ b/pkg/dcgmexporter/expcollector.go
@@ -35,7 +35,7 @@ var expMetricsFormat = `
 # HELP {{ $counter.FieldName }} {{ $counter.Help }}
 # TYPE {{ $counter.FieldName }} {{ $counter.PromType }}
 {{- range $metric := $metrics }}
-{{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"{{if $metric.MigProfile}},GPU_I_PROFILE="{{ $metric.MigProfile }}",GPU_I_ID="{{ $metric.GPUInstanceID }}"{{end}}{{if $metric.Hostname }},Hostname="{{ $metric.Hostname }}"{{end}}
+{{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",pci_bus_id="{{ $metric.GPUPCIBusID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"{{if $metric.MigProfile}},GPU_I_PROFILE="{{ $metric.MigProfile }}",GPU_I_ID="{{ $metric.GPUInstanceID }}"{{end}}{{if $metric.Hostname }},Hostname="{{ $metric.Hostname }}"{{end}}
 
 {{- range $k, $v := $metric.Labels -}}
 	,{{ $k }}="{{ $v }}"
@@ -174,6 +174,7 @@ func (c *expCollector) createMetric(labels map[string]string, mi MonitoringInfo,
 		GPUUUID:      mi.DeviceInfo.UUID,
 		GPUDevice:    fmt.Sprintf("nvidia%d", mi.DeviceInfo.GPU),
 		GPUModelName: gpuModel,
+		GPUPCIBusID:  mi.DeviceInfo.PCI.BusID,
 		Hostname:     c.hostname,
 
 		Labels:     labels,

--- a/pkg/dcgmexporter/gpu_collector.go
+++ b/pkg/dcgmexporter/gpu_collector.go
@@ -201,6 +201,7 @@ func ToSwitchMetric(
 				GPUUUID:      "",
 				GPUDevice:    fmt.Sprintf("nvswitch%d", mi.ParentId),
 				GPUModelName: "",
+				GPUPCIBusID:  "",
 				Hostname:     hostname,
 				Labels:       labels,
 				Attributes:   nil,
@@ -246,6 +247,7 @@ func ToCPUMetric(
 				GPUUUID:      "",
 				GPUDevice:    fmt.Sprintf("%d", mi.ParentId),
 				GPUModelName: "",
+				GPUPCIBusID:  "",
 				Hostname:     hostname,
 				Labels:       labels,
 				Attributes:   nil,
@@ -311,6 +313,7 @@ func ToMetric(
 			GPUUUID:      d.UUID,
 			GPUDevice:    fmt.Sprintf("nvidia%d", d.GPU),
 			GPUModelName: gpuModel,
+			GPUPCIBusID:  d.PCI.BusID,
 			Hostname:     hostname,
 
 			Labels:     labels,

--- a/pkg/dcgmexporter/pipeline.go
+++ b/pkg/dcgmexporter/pipeline.go
@@ -296,7 +296,7 @@ var migMetricsFormat = `
 # HELP {{ $counter.FieldName }} {{ $counter.Help }}
 # TYPE {{ $counter.FieldName }} {{ $counter.PromType }}
 {{- range $metric := $metrics }}
-{{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"{{if $metric.MigProfile}},GPU_I_PROFILE="{{ $metric.MigProfile }}",GPU_I_ID="{{ $metric.GPUInstanceID }}"{{end}}{{if $metric.Hostname }},Hostname="{{ $metric.Hostname }}"{{end}}
+{{ $counter.FieldName }}{gpu="{{ $metric.GPU }}",{{ $metric.UUID }}="{{ $metric.GPUUUID }}",pci_bus_id="{{ $metric.GPUPCIBusID }}",device="{{ $metric.GPUDevice }}",modelName="{{ $metric.GPUModelName }}"{{if $metric.MigProfile}},GPU_I_PROFILE="{{ $metric.MigProfile }}",GPU_I_ID="{{ $metric.GPUInstanceID }}"{{end}}{{if $metric.Hostname }},Hostname="{{ $metric.Hostname }}"{{end}}
 
 {{- range $k, $v := $metric.Labels -}}
 	,{{ $k }}="{{ $v }}"

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -96,6 +96,7 @@ type Metric struct {
 	GPUUUID      string
 	GPUDevice    string
 	GPUModelName string
+	GPUPCIBusID  string
 
 	UUID string
 

--- a/pkg/dcgmexporter/xid_collector_test.go
+++ b/pkg/dcgmexporter/xid_collector_test.go
@@ -221,16 +221,18 @@ func TestXIDCollector_Gather_Encode(t *testing.T) {
 			}))
 			continue
 		}
-		assert.Len(t, mv.Label, 8)
+		assert.Len(t, mv.Label, 9)
 		assert.Equal(t, "gpu", *mv.Label[0].Name)
 		assert.Equal(t, "UUID", *mv.Label[1].Name)
-		assert.Equal(t, "device", *mv.Label[2].Name)
-		assert.Equal(t, "modelName", *mv.Label[3].Name)
-		assert.Equal(t, "Hostname", *mv.Label[4].Name)
-		assert.Equal(t, "DCGM_FI_DRIVER_VERSION", *mv.Label[5].Name)
-		assert.Equal(t, "window_size_in_ms", *mv.Label[6].Name)
-		assert.Equal(t, "xid", *mv.Label[7].Name)
-		assert.NotEmpty(t, *mv.Label[7].Value)
+		assert.Equal(t, "pci_bus_id", *mv.Label[2].Name)
+		assert.NotEmpty(t, *mv.Label[2].Value)
+		assert.Equal(t, "device", *mv.Label[3].Name)
+		assert.Equal(t, "modelName", *mv.Label[4].Name)
+		assert.Equal(t, "Hostname", *mv.Label[5].Name)
+		assert.Equal(t, "DCGM_FI_DRIVER_VERSION", *mv.Label[6].Name)
+		assert.Equal(t, "window_size_in_ms", *mv.Label[7].Name)
+		assert.Equal(t, "xid", *mv.Label[8].Name)
+		assert.NotEmpty(t, *mv.Label[8].Value)
 	}
 }
 


### PR DESCRIPTION
This PR add `pci_bus_id` label for metrics to indicate the PCI Bus ID of the GPU.

Currently we have UUID for users to indicate a GPU card. For many reasons, you may also want to locate a GPU by its PCI Bus ID. 

For example, for cloud service providers, they supply GPU cards from the bare metal machines to Virtual Machines. However, GPU UUID is only aware to Guest system, therefore the cloud provider is unable to accurately tell the user that which GPU is broken. What the cloud provider have is only the PCI Bus ID.

Once added the `pci_bus_id` label, users can filter metrics by the Bus ID sent by the cloud provider, and receive alarms if their important tasks are affected.