### PR TITLE
[Helm] Enable ConfigMap mount by default

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -144,12 +144,12 @@ extraConfigMapVolumes:
       name: exporter-metrics-config-map
       items:
       - key: metrics
-        path: dcgm-metrics-included.csv
+        path: dcp-metrics-included.csv
 
 extraVolumeMounts:
   - name: exporter-metrics-volume
     mountPath: /etc/dcgm-exporter/dcp-metrics-included.csv
-    subPath: dcgm-metrics-included.csv
+    subPath: dcp-metrics-included.csv
 
 extraEnv: []
 #- name: EXTRA_VAR

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -73,8 +73,8 @@ podLabels: {}
 # Annotations to be added to dcgm-exporter pods
 podAnnotations: {}
 # Using this annotation which is required for prometheus scraping
- # prometheus.io/scrape: "true"
- # prometheus.io/port: "9400"
+# prometheus.io/scrape: "true"
+# prometheus.io/port: "9400"
 
 # The SecurityContext for the dcgm-exporter pods
 podSecurityContext: {}
@@ -85,7 +85,7 @@ securityContext:
   runAsNonRoot: false
   runAsUser: 0
   capabilities:
-     add: ["SYS_ADMIN"]
+    add: ["SYS_ADMIN"]
   # readOnlyRootFilesystem: true
 
 # Defines the dcgm-exporter service

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -138,15 +138,18 @@ extraHostVolumes: []
 #- name: host-binaries
 #  hostPath: /opt/bin
 
-extraConfigMapVolumes: []
-#- name: exporter-metrics-volume
-#  configMap:
-#    name: exporter-metrics-config-map
+extraConfigMapVolumes:
+  - name: exporter-metrics-volume
+    configMap:
+      name: exporter-metrics-config-map
+      items:
+      - key: metrics
+        path: dcgm-metrics-included.csv
 
-extraVolumeMounts: []
-#- name: host-binaries
-#  mountPath: /opt/bin
-#  readOnly: true
+extraVolumeMounts:
+  - name: exporter-metrics-volume
+    mountPath: /etc/dcgm-exporter/dcp-metrics-included.csv
+    subPath: dcgm-metrics-included.csv
 
 extraEnv: []
 #- name: EXTRA_VAR


### PR DESCRIPTION
Signed-off-by: chipzoller <chipzoller@gmail.com>

Closes #170

## Problem

The current version (3.4.2) Helm chart has a couple of problems.

1. It unnecessarily creates a ConfigMap and corresponding RBAC resources (ServiceAccount, Role, and RoleBinding) which are unused.
2. It makes it such that users are not able to modify the metrics emitted by default as the container embeds the CSV used to declare those metrics. Because of problem number one, this gives users the illusion that modifying the ConfigMap will result in DCGM-exporter using that as its operating config and it will not.

Users need an extensible ability to modify the metrics exposed by DCGM exporter after it has been deployed. For example, users may need additional software components deployed in the cluster which require non-default metrics sourced from DCGM-exporter. With no way to instruct DCGM-exporter to expose additional metrics, this will not work.

## Solution

Two easiest possible solutions to the above problems.

1. Mount the ConfigMap by default so the operating config is taken from it rather than internally. That is what this PR does.
2. Remove the default creation of the ConfigMap and supporting RBAC resources, and create new Helm values which allow users to opt-in to them.

This PR is intended as a conversation starter with the maintainers to see which approach, or possibly another, they would prefer.

After these changes, the net effect for users will be zero as the CSV used internally and that which is provided in the Helm chart are identical aside from some descriptors. This should be a non-disruptive upgrade for users.

If maintainers are open to the idea, my suggestion to make this more flexible for users is to allow users to specify contents of the ConfigMap in-line to the values file so they can include custom metrics during deployment.
