### PR TITLE
Rename default PCIe metrics for better readability

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -22,8 +22,8 @@ data:
       DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
       
       # PCIE
-      # DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
-      # DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
+      # DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.
+      # DCGM_FI_PROF_PCIE_RX_BYTES,  counter, Total number of bytes received through PCIe RX via NVML.
       DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
       
       # Utilization (the sample period varies depending on the product)

--- a/etc/1.x-compatibility-metrics.csv
+++ b/etc/1.x-compatibility-metrics.csv
@@ -15,8 +15,8 @@ dcgm_power_usage,              gauge, Power draw (in W).
 dcgm_total_energy_consumption, counter, Total energy consumption since boot (in mJ).
 
 # PCIe
-dcgm_pcie_tx_throughput,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
-dcgm_pcie_rx_throughput,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
+dcgm_fi_prof_pcie_tx_bytes,  counter, Total number of bytes transmitted through PCIe TX via NVML.
+dcgm_fi_prof_pcie_rx_bytes,  counter, Total number of bytes received through PCIe RX via NVML.
 dcgm_pcie_replay_counter, counter, Total number of PCIe retries.
 
 # Utilization (the sample period varies depending on the product)

--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -15,8 +15,8 @@ DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
 # PCIE
-# DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
-# DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
+# DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.
+# DCGM_FI_PROF_PCIE_RX_BYTES,  counter, Total number of bytes received through PCIe RX via NVML.
 DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 
 # Utilization (the sample period varies depending on the product)
@@ -87,4 +87,3 @@ DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interf
 # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
 DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
 DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
-

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -16,8 +16,8 @@ DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
 # PCIE
-DCGM_FI_DEV_PCIE_TX_THROUGHPUT,  counter, Total number of bytes transmitted through PCIe TX (in KB) via NVML.
-DCGM_FI_DEV_PCIE_RX_THROUGHPUT,  counter, Total number of bytes received through PCIe RX (in KB) via NVML.
+DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.
+DCGM_FI_PROF_PCIE_RX_BYTES,  counter, Total number of bytes received through PCIe RX via NVML.
 DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
 
 # Utilization (the sample period varies depending on the product)


### PR DESCRIPTION
Closes #354 

## Description

This PR updates the default PCIe metric from `DCGM_FI_DEV_PCIE_{TX,RX}_THROUGHPUT` to `DCGM_FI_PROF_PCIE_{TX,RX}_BYTES` in `./etc` files to align with the DCGM Documentation (Version 3.3).

## Background

According to the DCGM Documentation, `DCGM_FI_DEV_PCIE_{TX,RX}_THROUGHPUT` is deprecated and should be replaced with `DCGM_FI_PROF_PCIE_{TX,RX}_BYTES`. This change resolves issues reported in [Issue #167](https://github.com/NVIDIA/dcgm-exporter/issues/167).

## Changes Made

- Replaced `DCGM_FI_DEV_PCIE_{TX,RX}_THROUGHPUT` with `DCGM_FI_PROF_PCIE_{TX,RX}_BYTES` in `./etc/default-counters.csv`.

## References

- [DCGM Documentation - DCGM API Field IDs](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html#c.DCGM_FI_DEV_PCIE_TX_THROUGHPUT)
- [Issue #167 - Get DCGM_FI_DEV_PCIE_TX_THROUGHPUT metric failed](https://github.com/NVIDIA/dcgm-exporter/issues/167)
