### PR TITLE
Allow selecting the service's ClusterIP

### DIFF
--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -27,6 +27,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if eq .Values.service.type "ClusterIP" }}
+  clusterIP: {{ .Values.service.clusterIP | quote }}
+  {{- end }}
   ports:
   - name: "metrics"
     port: {{ .Values.service.port }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -93,6 +93,7 @@ service:
   # When enabled, the helm chart will create service
   enable: true
   type: ClusterIP
+  clusterIP: ""
   port: 9400
   address: ":9400"
   # Annotations to add to the service


### PR DESCRIPTION
This is mostly useful to be able to set it to "None", creating a headless service that can be scraped using DNS discovery (dns_sd_configs).

No change in default behavior.