### PR TITLE
fix: edit gitignore and require dir & file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 *.swo
 dcgm-exporter
+!/cmd/dcgm-exporter
 !etc/
 !deployment/
 .env


### PR DESCRIPTION
Set the "/cmd/dcgm-exporter" folder, which must be included, in gitignore.

Please refer to the issue contents
#381 