### PR TITLE
doc: golang >= 1.23 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To enable GPU-to-job mapping on the DCGM-exporter side, users must run the DCGM-
 
 In order to build dcgm-exporter ensure you have the following:
 
-* [Golang >= 1.21 installed](https://golang.org/)
+* [Golang >= 1.23 installed](https://golang.org/)
 * [DCGM installed](https://developer.nvidia.com/dcgm)
 
 ```shell


### PR DESCRIPTION
update the `golang` min requirement to the correct one.

```
$ make binary
go generate ./...
go: errors parsing go.mod:
/ctx/dcgm-exporter/go.mod:3: invalid go version '1.22.0': must match format 1.23
/ctx/dcgm-exporter/go.mod:5: unknown directive: toolchain
```

Once I installed v1.23 I was able to build it.

Thanks.