### PR TITLE
Fix empty clusterIP when no clusterIP is defined in values

### DIFF
--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -27,7 +27,7 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
-  {{- if eq .Values.service.type "ClusterIP" }}
+  {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}
   {{- end }}
   ports:


### PR DESCRIPTION
```
clusterIP:
```
Should only show up in manifest if `.Values.service.clusterIP` is defined. Otherwise it shows an empty value, which causes argoCD to report app as out of sync because of expects `spec.clusterIP` to have the auto assigned IP but manifest states it should be null value.