### PR TITLE
Add SYS_ADMIN capability requirement for docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Official documentation for DCGM-Exporter can be found on [docs.nvidia.com](https
 To gather metrics on a GPU node, simply start the `dcgm-exporter` container:
 
 ```shell
-docker run -d --gpus all --rm -p 9400:9400 nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
+docker run -d --gpus all --cap-add SYS_ADMIN --rm -p 9400:9400 nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
 curl localhost:9400/metrics
 # HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).
 # TYPE DCGM_FI_DEV_SM_CLOCK gauge


### PR DESCRIPTION
When starting without --cap-add SYS_ADMIN, an error message is displayed prompting to add the SYS_ADMIN capability. Therefore, I updated the instructions in the README to align with this requirement.

```
$ docker run --gpus all --rm -p 9400:9400 nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
Warning #2: dcgm-exporter doesn't have sufficient privileges to expose profiling metrics. To get profiling metrics with dcgm-exporter, use --cap-add SYS_ADMIN
2024/11/30 07:41:50 maxprocs: Leaving GOMAXPROCS=9: CPU quota undefined
time="2024-11-30T07:41:50Z" level=info msg="Starting dcgm-exporter"
time="2024-11-30T07:41:51Z" level=info msg="DCGM successfully initialized!"
time="2024-11-30T07:41:51Z" level=info msg="Collecting DCP Metrics"
time="2024-11-30T07:41:51Z" level=info msg="Falling back to metric file '/etc/dcgm-exporter/default-counters.csv'"
time="2024-11-30T07:41:51Z" level=info msg="Initializing system entities of type: GPU"
time="2024-11-30T07:41:51Z" level=info msg="Not collecting NvSwitch metrics; no fields to watch for device type: 3"
time="2024-11-30T07:41:51Z" level=info msg="Not collecting NvLink metrics; no fields to watch for device type: 6"
time="2024-11-30T07:41:51Z" level=info msg="Not collecting CPU metrics; no fields to watch for device type: 7"
time="2024-11-30T07:41:51Z" level=info msg="Not collecting CPU Core metrics; no fields to watch for device type: 8"
time="2024-11-30T07:41:51Z" level=fatal msg="Failed to watch metrics: Error watching fields: Host engine is running as non-root"
```