### PR TITLE
feat: add support for gpu sharing metrics in k8s

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -75,6 +75,7 @@ const (
 	CLIPodResourcesKubeletSocket  = "pod-resources-kubelet-socket"
 	CLIHPCJobMappingDir           = "hpc-job-mapping-dir"
 	CLINvidiaResourceNames        = "nvidia-resource-names"
+	CLIKubernetesVirtualGPUs      = "kubernetes-virtual-gpus"
 )
 
 func NewApp(buildVersion ...string) *cli.App {
@@ -243,6 +244,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   cli.NewStringSlice(),
 			Usage:   "Nvidia resource names for specified GPU type like nvidia.com/a100, nvidia.com/a10.",
 			EnvVars: []string{"NVIDIA_RESOURCE_NAMES"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIKubernetesVirtualGPUs,
+			Value:   false,
+			Usage:   "Capture metrics associated with virtual GPUs exposed by Kubernetes device plugins when using GPU sharing strategies, e.g. time-sharing or MPS.",
+			EnvVars: []string{"KUBERNETES_VIRTUAL_GPUS"},
 		},
 	}
 
@@ -639,5 +646,6 @@ func contextToConfig(c *cli.Context) (*dcgmexporter.Config, error) {
 		PodResourcesKubeletSocket:  c.String(CLIPodResourcesKubeletSocket),
 		HPCJobMappingDir:           c.String(CLIHPCJobMappingDir),
 		NvidiaResourceNames:        c.StringSlice(CLINvidiaResourceNames),
+		KubernetesVirtualGPUs:      c.Bool(CLIKubernetesVirtualGPUs),
 	}, nil
 }

--- a/pkg/dcgmexporter/config.go
+++ b/pkg/dcgmexporter/config.go
@@ -59,4 +59,5 @@ type Config struct {
 	PodResourcesKubeletSocket  string
 	HPCJobMappingDir           string
 	NvidiaResourceNames        []string
+	KubernetesVirtualGPUs      bool
 }

--- a/pkg/dcgmexporter/types.go
+++ b/pkg/dcgmexporter/types.go
@@ -38,6 +38,7 @@ var (
 	podAttribute       = "pod"
 	namespaceAttribute = "namespace"
 	containerAttribute = "container"
+	vgpuAttribute      = "vgpu"
 
 	hpcJobAttribute = "hpc_job"
 
@@ -148,6 +149,7 @@ type PodInfo struct {
 	Name      string
 	Namespace string
 	Container string
+	VGPU      string
 }
 
 // MetricsByCounter represents a map where each Counter is associated with a slice of Metric objects


### PR DESCRIPTION
We add support for capturing separate metrics when running dcgm-exporter in K8s clusters that have GPU sharing enabled, including time-sharing and MPS. This should now support GPU sharing on MIG devices as well.

We ensure this is supported for both the NVIDIA and GKE device plugins, respectively at:
* https://github.com/NVIDIA/k8s-device-plugin
* https://github.com/GoogleCloudPlatform/container-engine-accelerators

First, we make a small fix to the Kubernetes PodMapper tranform processor. Specifically we update the regular expression used in building the device mapping to properly capture pod attributes in both MIG and MIG-with-sharing GPUs in GKE.

The bulk of the change is guarded by a new configuration parameter, which can be passed in as a flag `--kubernetes-virtual-gpus` or as an environment variable `KUBERNETES_VIRTUAL_GPUS`. If set, the Kubernetes PodMapper tranform processor uses a different mechanism to build the device mapping, which creates a copy of the metric for every shared (i.e. virtual) GPU exposed by the device plugin. To disambiguate the generated timeseries, it adds a new label "vgpu" set to the detected shared GPU replica.

This also fixes an issue where pod attributes are not guaranteed to be consistently associated with the same metric. If the podresources API does not consistently return the device-ids in the same order between calls, the device-to-pod association in the map can change between scrapes due to an overwrite that happens in the Process loop.

Ultimately, we may wish to make this the default behavior. However, guarding it behind a flag:
1. Mitigates any risk of the change in case of bugs
2. Given the feature adds a new label, it is possible PromQL queries performing deaggregation using, e.g.  `without` or `ignore` functions, may break existing dashboards and alerts. Allowing users to opt-in via a flag ensures backwards compatibility in these scenarios.

Finally, we update the unit tests to ensure thorough coverage for the changes.