### PR TITLE
fix: enable pod attributes for gpu-sharing in gke

### DIFF
--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -41,7 +41,8 @@ import (
 var (
 	connectionTimeout = 10 * time.Second
 
-	gkeMigDeviceIDRegex            = regexp.MustCompile(`^nvidia([0-9]+)/gi([0-9]+)$`)
+	// Allow for MIG devices with or without GPU sharing to match in GKE.
+	gkeMigDeviceIDRegex            = regexp.MustCompile(`^nvidia([0-9]+)/gi([0-9]+)(/vgpu[0-9]+)?$`)
 	gkeVirtualGPUDeviceIDSeparator = "/vgpu"
 )
 

--- a/internal/pkg/transformation/kubernetes_test.go
+++ b/internal/pkg/transformation/kubernetes_test.go
@@ -118,6 +118,20 @@ func TestProcessPodMapper_WithD_Different_Format_Of_DeviceID(t *testing.T) {
 			PODGPUID:            "b8ea3855-276c-c9cb-b366-c6fa655957c5",
 			NvidiaResourceNames: []string{"nvidia.com/a100"},
 		},
+		{
+			KubernetesGPUIDType: appconfig.DeviceName,
+			ResourceName:        appconfig.NvidiaResourceName,
+			MetricMigProfile:    "1g.10gb",
+			GPUInstanceID:       0,
+			PODGPUID:            "nvidia0/gi0/vgpu0",
+		},
+		{
+			KubernetesGPUIDType: appconfig.DeviceName,
+			ResourceName:        appconfig.NvidiaResourceName,
+			MetricMigProfile:    "1g.10gb",
+			GPUInstanceID:       1,
+			PODGPUID:            "nvidia0/gi1/vgpu0",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
We make a small fix to the Kubernetes PodMapper tranform processor.

Specifically we update the regular expression used in building the device mapping to properly capture pod attributes in both MIG and [MIG-with-sharing](https://cloud.google.com/kubernetes-engine/docs/how-to/timesharing-gpus#use-with-multi-instance-gpu) GPUs in GKE.