### PR TITLE
feat: add log formatting

### DIFF
--- a/cmd/dcgm-exporter/main.go
+++ b/cmd/dcgm-exporter/main.go
@@ -20,8 +20,6 @@ import (
 	"log/slog"
 	"os"
 
-	_ "go.uber.org/automaxprocs"
-
 	"github.com/NVIDIA/dcgm-exporter/pkg/cmd"
 )
 

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -325,10 +325,10 @@ func configureLogFormat(c *cli.Context) error {
 	var logger *slog.Logger
 	switch logFormat {
 	case "text":
-		logger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+		logger = slog.New(slog.NewTextHandler(os.Stderr, nil))
 		slog.SetDefault(logger)
 	case "json":
-		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+		logger = slog.New(slog.NewJSONHandler(os.Stderr, nil))
 		slog.SetDefault(logger)
 	default:
 		return fmt.Errorf("invalid %s parameter values: %s", CLILogFormat, logFormat)


### PR DESCRIPTION
We introduce log formatting to support both text and json formats. This can be configured through a CLI flag "log-format" or env var "DCGM_EXPORTER_LOG_FORMAT".

Notably, the log format will capture any DCGM logging that is configured.

We also move the automaxprocs call from an unused import to be explicitly called when starting the dcgm exporter to ensure its logging format honors the configuration.