### PR TITLE
(helm chart) Make priorityClassName optional

### DIFF
--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: dcgm-exporter
 description: A Helm chart for DCGM exporter
-version: "4.0.0"
+version: "4.0.1"
 kubeVersion: ">= 1.19.0-0"
 appVersion: "4.0.0"
 sources:

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -48,7 +48,9 @@ spec:
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
-      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -61,6 +61,9 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# Defines the priority class used by the pod
+priorityClassName: "system-node-critical"
+
 rollingUpdate:
   # Specifies maximum number of DaemonSet pods that can be unavailable during the update
   maxUnavailable: 1


### PR DESCRIPTION
The chart currently (1) requires `priorityClassName` be set and (2) doesn't specify it as an input value, so you can't set it. 

Keeping the same default, I'm allowing priorityClassName to be omitted, which simplifies the process of running this in a non-standard namespace. 
