### PR TITLE
Update values.yaml

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -17,7 +17,7 @@ image:
   pullPolicy: IfNotPresent
   # Image tag defaults to AppVersion, but you can use the tag key
   # for the image tag, e.g:
-  tag: 4.0.0-4.0.0-ubuntu22.04
+  tag: 4.0.0-4.0.1-ubuntu22.04
 
 # Change the following reference to "/etc/dcgm-exporter/default-counters.csv"
 # to stop profiling metrics from DCGM


### PR DESCRIPTION
Image tag version 4.0.0-4.0.0-ubuntu22.04 doesn't exist and ImagePullBackOff error occurs when using it. Therefore, I updated it to the existing version 4.0.0-4.0.1-ubuntu22.04 .