### PR TITLE
fix: install required packages for DCP metrics

### DIFF
--- a/docker/Dockerfile.ubi
+++ b/docker/Dockerfile.ubi
@@ -63,7 +63,7 @@ LABEL io.k8s.display-name="NVIDIA DCGM Exporter"
 ARG DCGM_VERSION
 
 RUN dnf update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y \
-	&& dnf install --nodocs --setopt=install_weak_deps=False -y datacenter-gpu-manager-4-core libcap \
+	&& dnf install --nodocs --setopt=install_weak_deps=False -y datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary libcap \
 	&& dnf -y clean all\
 	&& rm -rf /var/cache/yum\
 	&& rm -rfd /usr/local/dcgm/bindings /usr/local/dcgm/sdk_samples /usr/share/nvidia-validation-suite \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -71,7 +71,7 @@ COPY --from=builder /usr/bin/dcgm-exporter /usr/bin/
 COPY etc /etc/dcgm-exporter
 ENV DEBIAN_FRONTEND=noninteractive
 RUN echo "$TARGETARCH" && apt-get -qq update && apt-get -qq install -y --no-install-recommends \
-    datacenter-gpu-manager-4-core libcap2-bin \
+    datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary libcap2-bin \
     && apt-get -qq -y clean \
     && apt-get -qq -y autoclean \
     && apt-get -qq autoremove -y \


### PR DESCRIPTION
In DCGM 4.0, packages are separated into multiple small packages.
The library needed for enable profiling module, libdcgmmoduleprofiling.so.4 is not included in package datacenter-gpu-manager-4-core, but in package gpu-manager-4-proprietary.

This fixes #449 