### PR TITLE
feat(app): reload on config change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/bits-and-blooms/bitset v1.22.0
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/mittwald/go-helm-client v0.12.16

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/foxcpp/go-mockdns v1.1.0 h1:jI0rD8M0wuYAxL7r/ynTrCQQq0BVqfB99Vgk7Dlme
 github.com/foxcpp/go-mockdns v1.1.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=


### PR DESCRIPTION
here we take advantage of all of the wiring in place to handle os signals, and send a hangup when the config file changes

tested locally running in docker

built with:

```
docker build . -f docker/Dockerfile.ubuntu -t newdcgm --build-arg "GOLANG_VERSION=1.23.0"
```

docker logs
```
»  docker run --privileged --rm -it --name "dcgm" newdcgm -f /etc/dcgm-exporter/dcp-metrics-included.csv
2025/04/10 22:45:41 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
2025/04/10 22:45:41 INFO Starting dcgm-exporter Version=4.2.0-4.1.0
2025/04/10 22:45:41 INFO Attempting to initialize DCGM.
2025/04/10 22:45:41 INFO Initialized DCGM Fields module.
2025/04/10 22:45:41 INFO DCGM successfully initialized!
2025/04/10 22:45:41 INFO Attempting to initialize NVML library.
2025/04/10 22:45:41 INFO NVML provider successfully initialized!
2025/04/10 22:45:42 INFO Collecting DCP Metrics
2025/04/10 22:45:42 INFO Falling back to metric file '/etc/dcgm-exporter/dcp-metrics-included.csv'
2025/04/10 22:45:42 INFO Initializing system entities of type 'GPU'
2025/04/10 22:45:42 INFO Initializing system entities of type 'NvSwitch'
2025/04/10 22:45:42 INFO Not collecting NvSwitch metrics; no switches to monitor
2025/04/10 22:45:42 INFO Initializing system entities of type 'NvLink'
2025/04/10 22:45:42 INFO Not collecting NvLink metrics; no switches to monitor
2025/04/10 22:45:42 INFO Initializing system entities of type 'CPU'
2025/04/10 22:45:42 INFO Not collecting CPU metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:45:42 INFO Initializing system entities of type 'CPU Core'
2025/04/10 22:45:42 INFO Not collecting CPU Core metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:45:42 INFO Starting webserver
2025/04/10 22:45:42 INFO Watching for changes in file file=/etc/dcgm-exporter/dcp-metrics-included.csv
2025/04/10 22:45:42 INFO Listening on address=[::]:9400
2025/04/10 22:45:42 INFO TLS is disabled. http2=false address=[::]:9400
2025/04/10 22:45:55 INFO Reloading metrics server
2025/04/10 22:45:55 INFO Received signal signal=hangup
2025/04/10 22:45:55 INFO Starting dcgm-exporter Version=4.2.0-4.1.0
2025/04/10 22:45:55 INFO DCGM already initialized
2025/04/10 22:45:55 INFO DCGM successfully initialized!
2025/04/10 22:45:55 INFO NVML already initialized.
2025/04/10 22:45:55 INFO NVML provider successfully initialized!
2025/04/10 22:45:55 INFO Collecting DCP Metrics
2025/04/10 22:45:55 INFO Falling back to metric file '/etc/dcgm-exporter/dcp-metrics-included.csv'
2025/04/10 22:45:55 INFO Initializing system entities of type 'GPU'
2025/04/10 22:45:55 INFO Initializing system entities of type 'NvSwitch'
2025/04/10 22:45:55 INFO Not collecting NvSwitch metrics; no switches to monitor
2025/04/10 22:45:55 INFO Initializing system entities of type 'NvLink'
2025/04/10 22:45:55 INFO Not collecting NvLink metrics; no switches to monitor
2025/04/10 22:45:55 INFO Initializing system entities of type 'CPU'
2025/04/10 22:45:55 INFO Not collecting CPU metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:45:55 INFO Initializing system entities of type 'CPU Core'
2025/04/10 22:45:55 INFO Not collecting CPU Core metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:45:55 INFO Watching for changes in file file=/etc/dcgm-exporter/dcp-metrics-included.csv
2025/04/10 22:45:55 INFO Starting webserver
2025/04/10 22:45:55 INFO Listening on address=[::]:9400
2025/04/10 22:45:55 INFO TLS is disabled. http2=false address=[::]:9400
2025/04/10 22:46:13 INFO Reloading metrics server
2025/04/10 22:46:13 INFO Reloading metrics server
2025/04/10 22:46:13 INFO Received signal signal=hangup
2025/04/10 22:46:13 INFO Starting dcgm-exporter Version=4.2.0-4.1.0
2025/04/10 22:46:13 INFO DCGM already initialized
2025/04/10 22:46:13 INFO DCGM successfully initialized!
2025/04/10 22:46:13 INFO NVML already initialized.
2025/04/10 22:46:13 INFO NVML provider successfully initialized!
2025/04/10 22:46:13 INFO Collecting DCP Metrics
2025/04/10 22:46:13 INFO Falling back to metric file '/etc/dcgm-exporter/dcp-metrics-included.csv'
2025/04/10 22:46:13 INFO Initializing system entities of type 'GPU'
2025/04/10 22:46:13 INFO Initializing system entities of type 'NvSwitch'
2025/04/10 22:46:13 INFO Not collecting NvSwitch metrics; no switches to monitor
2025/04/10 22:46:13 INFO Initializing system entities of type 'NvLink'
2025/04/10 22:46:13 INFO Not collecting NvLink metrics; no switches to monitor
2025/04/10 22:46:13 INFO Initializing system entities of type 'CPU'
2025/04/10 22:46:13 INFO Not collecting CPU metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:46:13 INFO Initializing system entities of type 'CPU Core'
2025/04/10 22:46:13 INFO Not collecting CPU Core metrics; error retrieving DCGM CPU hierarchy: This request is serviced by a module of DCGM that is not currently loaded
2025/04/10 22:46:13 INFO Watching for changes in file file=/etc/dcgm-exporter/dcp-metrics-included.csv
2025/04/10 22:46:13 INFO Starting webserver
2025/04/10 22:46:13 INFO Listening on address=[::]:9400
2025/04/10 22:46:13 INFO TLS is disabled. http2=false address=[::]:9400
```

editing the dcp metrics included file to remove the `DCGM_FI_DEV_SM_CLOCK` metric:
```
root@5a9659017c9e:/# vim /etc/dcgm-exporter/dcp-metrics-included.csv
root@5a9659017c9e:/# curl localhost:9400/metrics | grep -i DCGM_FI_DEV_SM_CLOCK
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  6804    0  6804    0     0  1090k      0 --:--:-- --:--:-- --:--:-- 1328k
root@5a9659017c9e:/# vim /etc/dcgm-exporter/dcp-metrics-included.csv
root@5a9659017c9e:/# curl localhost:9400/metrics | grep -i DCGM_FI_DEV_SM_CLOCK
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  7108    0  710# HELP DCGM_FI_DEV_SM_CLOCK SM clock frequency (in MHz).
8 # TYPE DCGM_FI_DEV_SM_CLOCK gauge
  DCGM_FI_DEV_SM_CLOCK{gpu="0",UUID="GPU-b65939ac-4bc0-93dd-f662-99f7a5f0e930",pci_bus_id="00000000:05:00.0",device="nvidia0",modelName="Quadro RTX 4000",Hostname="5a9659017c9e",DCGM_FI_DRIVER_VERSION="535.54.03"} 1005
 0     0  1774k      0 --:--:-- --:--:-- --:--:-- 2313k
root@5a9659017c9e:/#
```