### PR TITLE
feat: Add the createRuntimeClass parameter to pre-install the RuntimeClass resource

### DIFF
--- a/deployment/templates/runtime-class.yaml
+++ b/deployment/templates/runtime-class.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.createRuntimeClass .Values.runtimeClassName }}
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: {{ .Values.runtimeClassName }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+handler: nvidia
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -51,6 +51,8 @@ namespaceOverride: ""
 
 # Defines the runtime class that will be used by the pod
 runtimeClassName: ""
+# Whether to create runtime class, name comes from runtimeClassName when it is set
+createRuntimeClass: false
 # Defines serviceAccount names for components.
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
helm values.yaml adds the createRuntimeClass parameter, which allows you to choose whether or not to create the corresponding RuntimeClass resource if the user sets the parameter runtimeClassName.