### PR TITLE
fix(metrics): unsupported character in float while parsing

### DIFF
--- a/internal/pkg/collector/gpu_collector.go
+++ b/internal/pkg/collector/gpu_collector.go
@@ -278,6 +278,10 @@ func toMetric(
 				attrs["err_msg"] = unknownErr
 			}
 		}
+		if val.FieldType == dcgm.DCGM_FT_STRING {
+			attrs[counter.FieldName] = v // converse string value in prometheus to label , prometheus can't accept string type in value
+			v = "1"                      //set value to number, 1 don't mean anything
+		}
 
 		m := Metric{
 			Counter: counter,
@@ -366,6 +370,9 @@ func toString(value dcgm.FieldValue_v1) string {
 		default:
 			return v
 		}
+	case dcgm.DCGM_FT_BINARY:
+		// I don't know how to convert this variable, I try to value.String() but result is empty
+		return value.String()
 	}
 
 	return FailedToConvert


### PR DESCRIPTION
solve issue:  https://github.com/NVIDIA/dcgm-exporter/issues/488

when I enabling MIG on the gpu host , I noticed that some metrics are converted incorrectly and are incompatible with Prometheus. Examples include:

DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR
DCGM_FI_DEV_MIG_MODE
DCGM_FI_DEV_SM_CLOCK