### PR TITLE
[helm][k8s-service] add support for setting internalTrafficPolicy

### DIFF
--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -30,6 +30,7 @@ spec:
   {{- if .Values.service.clusterIP }}
   clusterIP: {{ .Values.service.clusterIP | quote }}
   {{- end }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
   ports:
   - name: "metrics"
     port: {{ .Values.service.port }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -93,6 +93,8 @@ service:
   # When enabled, the helm chart will create service
   enable: true
   type: ClusterIP
+  # Accepts either "Cluster" or "Local", choose Local if you want to route internal traffic within the node only
+  internalTrafficPolicy: Cluster
   clusterIP: ""
   port: 9400
   address: ":9400"


### PR DESCRIPTION
This PR was created in response to the gpu-operator issue https://github.com/NVIDIA/gpu-operator/issues/1439

The OP of the GitHub issue would like to set the InternalTrafficPolicy as they have their own monitoring system running as a daemonset and they want to ensure that those pods only scrape the metrics from the dcgm-exporter pods in the same node

I wanted to raise a PR here to see if this change makes sense before making similar changes in gpu-operator