### PR TITLE
chore: add labels to configmap and remove label duplication

### DIFF
--- a/deployment/templates/_helpers.tpl
+++ b/deployment/templates/_helpers.tpl
@@ -61,6 +61,7 @@ Selector labels
 {{- define "dcgm-exporter.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "dcgm-exporter.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: {{ include "dcgm-exporter.name" . }}
 {{- end -}}
 
 {{/*

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -19,7 +19,6 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -31,12 +30,10 @@ spec:
   selector:
     matchLabels:
       {{- include "dcgm-exporter.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "dcgm-exporter"
   template:
     metadata:
       labels:
         {{- include "dcgm-exporter.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: "dcgm-exporter"
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}

--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: exporter-metrics-config-map
   namespace: {{ include "dcgm-exporter.namespace" . }}
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
 data:
 {{- if .Values.customMetrics }}
   metrics: |
@@ -12,30 +14,30 @@ data:
       # Format
       # If line starts with a '#' it is considered a comment
       # DCGM FIELD, Prometheus metric type, help message
-      
+
       # Clocks
       DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
       DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
-      
+
       # Temperature
       DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
       DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
-      
+
       # Power
       DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
       DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
-      
+
       # PCIE
       # DCGM_FI_PROF_PCIE_TX_BYTES,  counter, Total number of bytes transmitted through PCIe TX via NVML.
       # DCGM_FI_PROF_PCIE_RX_BYTES,  counter, Total number of bytes received through PCIe RX via NVML.
       DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
-      
+
       # Utilization (the sample period varies depending on the product)
       DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
       DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
       DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
       DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
-      
+
       # Errors and violations
       DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
       # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
@@ -44,22 +46,22 @@ data:
       # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
       # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
       # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
-      
+
       # Memory usage
       DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
       DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
-      
+
       # ECC
       # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
       # DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
       # DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
       # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
-      
+
       # Retired pages
       # DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
       # DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
       # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
-      
+
       # NVLink
       # DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
       # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
@@ -67,15 +69,15 @@ data:
       # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
       DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
       # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
-      
+
       # VGPU License status
       DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
-      
+
       # Remapped rows
       DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
       DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
       DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
-      
+
       # DCP metrics
       DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.
       # DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned.

--- a/deployment/templates/role.yaml
+++ b/deployment/templates/role.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/deployment/templates/rolebinding.yaml
+++ b/deployment/templates/rolebinding.yaml
@@ -5,12 +5,11 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
 subjects:
 - kind: ServiceAccount
   name: {{ include "dcgm-exporter.serviceAccountName" . }}
   namespace: {{ include "dcgm-exporter.namespace" . }}
 roleRef:
-  kind: Role 
+  kind: Role
   name: dcgm-exporter-read-cm
   apiGroup: rbac.authorization.k8s.io

--- a/deployment/templates/service-monitor.yaml
+++ b/deployment/templates/service-monitor.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
     {{- if .Values.serviceMonitor.additionalLabels }}
     {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
   {{- with .Values.service.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}

--- a/deployment/templates/serviceaccount.yaml
+++ b/deployment/templates/serviceaccount.yaml
@@ -20,7 +20,6 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
-    app.kubernetes.io/component: "dcgm-exporter"
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deployment/templates/tls-secret.yaml
+++ b/deployment/templates/tls-secret.yaml
@@ -20,7 +20,6 @@ metadata:
   name: {{ (include "dcgm-exporter.tlsCertsSecretName" .) }}
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/component: "dcgm-exporter"
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
 type: Opaque
 data:

--- a/deployment/templates/web-config-configmap.yaml
+++ b/deployment/templates/web-config-configmap.yaml
@@ -18,7 +18,6 @@ metadata:
   name: {{ include "dcgm-exporter.webConfigConfigMap" . }}
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
-    app.kubernetes.io/component: "dcgm-exporter"
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
 data:
   web-config.yaml: |


### PR DESCRIPTION
Minor Helm chart improvements. Adds the charts labels to the metrics configmap and adds the label `app.kubernetes.io/component: dcgm-exporter` to the selector labels defined in _helpers.tpl to reduce duplication.
Example of what the labels/selector labels looks like with the changes
``` 
# Generated using `helm template example-dcgm-exporter ./`
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: example-dcgm-exporter
  namespace: example
  labels:
    helm.sh/chart: dcgm-exporter-4.1.1
    app.kubernetes.io/name: dcgm-exporter
    app.kubernetes.io/instance: example-dcgm-exporter
    app.kubernetes.io/component: dcgm-exporter
    app.kubernetes.io/version: "4.1.1"
    app.kubernetes.io/managed-by: Helm
spec:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
      maxSurge: 0
  selector:
    matchLabels:
      app.kubernetes.io/name: dcgm-exporter
      app.kubernetes.io/instance: example-dcgm-exporter
      app.kubernetes.io/component: dcgm-exporter
```