### PR TITLE
Fix: update podresourcesapi from v1alpha1 to v1 to fix issue with native sidecar metrics labels

### DIFF
--- a/internal/pkg/integration_test/collector_test.go
+++ b/internal/pkg/integration_test/collector_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
-	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	"k8s.io/utils/ptr"
 
 	mockdcgmprovider "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/dcgmprovider"
@@ -288,7 +288,7 @@ func TestClockEventsCollector_Gather(t *testing.T) {
 		gpuIDsAsString[i] = fmt.Sprint(g)
 	}
 
-	v1alpha1.RegisterPodResourcesListerServer(server,
+	v1.RegisterPodResourcesListerServer(server,
 		testutils.NewMockPodResourcesServer(appconfig.NvidiaResourceName, gpuIDsAsString))
 	// Tell that the app is running on K8S
 	config.Kubernetes = true

--- a/internal/pkg/integration_test/transformation_test.go
+++ b/internal/pkg/integration_test/transformation_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/collector"
@@ -67,7 +67,7 @@ func TestProcessPodMapper(t *testing.T) {
 	socketPath := tmpDir + "/kubelet.sock"
 	server := grpc.NewServer()
 	gpus := getGPUUUIDs(arbirtaryMetric)
-	v1alpha1.RegisterPodResourcesListerServer(server,
+	v1.RegisterPodResourcesListerServer(server,
 		testutils.NewMockPodResourcesServer(appconfig.NvidiaResourceName, gpus))
 
 	cleanup = testutils.StartMockServer(t, server, socketPath)

--- a/internal/pkg/testutils/test_utils.go
+++ b/internal/pkg/testutils/test_utils.go
@@ -230,6 +230,41 @@ func (s *MockPodResourcesServer) List(
 	}, nil
 }
 
+func (s *MockPodResourcesServer) Get(
+	ctx context.Context, req *v1.GetPodResourcesRequest,
+) (*v1.GetPodResourcesResponse, error) {
+	return &v1.GetPodResourcesResponse{
+		PodResources: &v1.PodResources{
+			Name:      "gpu-pod-0",
+			Namespace: "default",
+			Containers: []*v1.ContainerResources{
+				{
+					Name: "default",
+					Devices: []*v1.ContainerDevices{
+						{
+							ResourceName: s.resourceName,
+							DeviceIds:    s.gpus,
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func (s *MockPodResourcesServer) GetAllocatableResources(
+	ctx context.Context, req *v1.AllocatableResourcesRequest,
+) (*v1.AllocatableResourcesResponse, error) {
+	return &v1.AllocatableResourcesResponse{
+		Devices: []*v1.ContainerDevices{
+			{
+				ResourceName: s.resourceName,
+				DeviceIds:    s.gpus,
+			},
+		},
+	}, nil
+}
+
 func StartMockServer(t *testing.T, server *grpc.Server, socket string) func() {
 	l, err := net.Listen("unix", socket)
 	require.NoError(t, err)

--- a/internal/pkg/testutils/test_utils.go
+++ b/internal/pkg/testutils/test_utils.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
-	"k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+	v1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	mockdeviceinfo "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/deviceinfo"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/deviceinfo"
@@ -203,18 +203,18 @@ func NewMockPodResourcesServer(resourceName string, gpus []string) *MockPodResou
 }
 
 func (s *MockPodResourcesServer) List(
-	ctx context.Context, req *v1alpha1.ListPodResourcesRequest,
-) (*v1alpha1.ListPodResourcesResponse, error) {
-	podResources := make([]*v1alpha1.PodResources, len(s.gpus))
+	ctx context.Context, req *v1.ListPodResourcesRequest,
+) (*v1.ListPodResourcesResponse, error) {
+	podResources := make([]*v1.PodResources, len(s.gpus))
 
 	for i, gpu := range s.gpus {
-		podResources[i] = &v1alpha1.PodResources{
+		podResources[i] = &v1.PodResources{
 			Name:      fmt.Sprintf("gpu-pod-%d", i),
 			Namespace: "default",
-			Containers: []*v1alpha1.ContainerResources{
+			Containers: []*v1.ContainerResources{
 				{
 					Name: "default",
-					Devices: []*v1alpha1.ContainerDevices{
+					Devices: []*v1.ContainerDevices{
 						{
 							ResourceName: s.resourceName,
 							DeviceIds:    []string{gpu},
@@ -225,7 +225,7 @@ func (s *MockPodResourcesServer) List(
 		}
 	}
 
-	return &v1alpha1.ListPodResourcesResponse{
+	return &v1.ListPodResourcesResponse{
 		PodResources: podResources,
 	}, nil
 }

--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -30,7 +30,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/collector"

--- a/internal/pkg/transformation/kubernetes_test.go
+++ b/internal/pkg/transformation/kubernetes_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
-	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1alpha1"
+	podresourcesapi "k8s.io/kubelet/pkg/apis/podresources/v1"
 
 	mockdeviceinfo "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/deviceinfo"
 	mocknvmlprovider "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/nvmlprovider"


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/dcgm-exporter/issues/497

This is fixed by updating the `podresourcesapi` from `v1alpha1` to `v1`, as the former doesn't include native sidecar container (restartable initContainers) in the pod-resources response output.

Tested in EKS cluster with this fix, native sidecar container `DCGM_.*` metrics now contain the correct pod and namespace labels.