### PR TITLE
[helm] Add hostPID field to values.yaml and DaemonSet template for Helm

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -46,6 +46,7 @@ spec:
       runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
       priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
+      hostPID: {{ .Values.hostPID | default false }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -49,6 +49,10 @@ fullnameOverride: ""
 # Overrides the deployment namespace
 namespaceOverride: ""
 
+# hostPID allows the DCGM-Exporter container to see processes on the host node
+# Default: false
+hostPID: false
+
 # Defines the runtime class that will be used by the pod
 runtimeClassName: ""
 # Defines serviceAccount names for components.


### PR DESCRIPTION
Add a new `hostPID` Helm value (default: false) that, when set to true, injects hostPID: true into the DaemonSet Pod spec so dcgm-exporter pods can share the host PID namespace.

We need visibility into host‐level GPU processes (we know the PIDs using the GPU from DCGM) so that the exporter can map those processes back to Kubernetes pods/containers. 

NOTE: We also require identical `hostPID` support in the NVIDIA GPU Operator chart 