### PR TITLE
Fix duplicate key in Helm chart

### DIFF
--- a/deployment/templates/service-monitor.yaml
+++ b/deployment/templates/service-monitor.yaml
@@ -27,7 +27,6 @@ spec:
   selector:
     matchLabels:
       {{- include "dcgm-exporter.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "dcgm-exporter"
   namespaceSelector:
     matchNames:
     - "{{ include "dcgm-exporter.namespace" . }}"


### PR DESCRIPTION
Hello,  
when installing from the main branch, I encountered the following error:  

```
  Warning  InstallFailed     8s (x5 over 20s)  helm-controller  Helm install failed for release kube-system/nvdp-metrics with chart dcgm-exporter@4.1.2: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:  
  line 36: mapping key "app.kubernetes.io/component" already defined at line 35
```

This commit removes the duplicate key.