### PR TITLE
Kubernetes Pod Label Support

### DIFF
--- a/deployment/templates/clusterrole.yaml
+++ b/deployment/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "list"]
+{{- end }}

--- a/deployment/templates/clusterrolebinding.yaml
+++ b/deployment/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dcgm-exporter.serviceAccountName" . }}
+  namespace: {{ include "dcgm-exporter.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "dcgm-exporter.fullname" . }}-read-pods
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -112,6 +112,10 @@ spec:
         env:
         - name: "DCGM_EXPORTER_KUBERNETES"
           value: "true"
+        {{- if .Values.kubernetes.enablePodLabels }}
+        - name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"
+          value: "true"
+        {{- end }}
         - name: "DCGM_EXPORTER_LISTEN"
           value: "{{ .Values.service.address }}"
         - name: NODE_NAME

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -194,6 +194,19 @@ basicAuth:
   #Object containing <user>:<passwords> key-value pairs for each user that will have access via basic authentication
   users: {}
 
+# Kubernetes integration settings
+kubernetes:
+  # Enable Kubernetes pod labels in metrics
+  # When enabled, metrics will include labels from the pods that are using the GPUs
+  # This requires cluster-level read permissions to pods
+  enablePodLabels: false
+
+  # RBAC settings for Kubernetes integration
+  rbac:
+    # Automatically creates ClusterRole and ClusterRoleBinding for pod access when enablePodLabels is true
+    # Set to false if you want to manage RBAC resources manually
+    create: true
+
 # Customized list of metrics to emit. Expected to be in the same format (CSV) as the default list.
 # Must be the complete list and is not additive. If unset, the default list will take effect.
 # customMetrics: |

--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -33,6 +33,7 @@ type Config struct {
 	Address                    string
 	CollectInterval            int
 	Kubernetes                 bool
+	KubernetesEnablePodLabels  bool
 	KubernetesGPUIdType        KubernetesGPUIDType
 	CollectDCP                 bool
 	UseOldNamespace            bool

--- a/internal/pkg/transformation/types.go
+++ b/internal/pkg/transformation/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/collector"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/deviceinfo"
+	"k8s.io/client-go/kubernetes"
 )
 
 //go:generate go run -v go.uber.org/mock/mockgen  -destination=../../mocks/pkg/transformations/mock_transformer.go -package=transformation -copyright_file=../../../hack/header.txt . Transform
@@ -31,6 +32,7 @@ type Transform interface {
 
 type PodMapper struct {
 	Config *appconfig.Config
+	Client kubernetes.Interface
 }
 
 type PodInfo struct {
@@ -38,4 +40,5 @@ type PodInfo struct {
 	Namespace string
 	Container string
 	VGPU      string
+	Labels    map[string]string
 }

--- a/internal/pkg/utils/utils.go
+++ b/internal/pkg/utils/utils.go
@@ -22,9 +22,13 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
+	"regexp"
 	"sync"
 	"time"
 )
+
+// invalidLabelCharRE is a regular expression that matches any character that is not a letter, digit, or underscore.
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 func WaitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) error {
 	c := make(chan struct{})
@@ -82,4 +86,8 @@ func CleanupOnError(cleanups []func()) []func() {
 	}
 
 	return nil
+}
+
+func SanitizeLabelName(s string) string {
+	return invalidLabelCharRE.ReplaceAllString(s, "_")
 }

--- a/internal/pkg/utils/utils_test.go
+++ b/internal/pkg/utils/utils_test.go
@@ -129,3 +129,26 @@ func TestCleanupOnError(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeLabelName(t *testing.T) {
+	t.Run("Sanitize label with invalid characters", func(t *testing.T) {
+		input := "label.with.dots/and-slashes"
+		expected := "label_with_dots_and_slashes"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Sanitize label with special characters", func(t *testing.T) {
+		input := "label@with#special!chars"
+		expected := "label_with_special_chars"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("Keep valid label unchanged", func(t *testing.T) {
+		input := "valid_label_name"
+		expected := "valid_label_name"
+		got := SanitizeLabelName(input)
+		assert.Equal(t, expected, got)
+	})
+}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -69,6 +69,7 @@ const (
 	CLIAddress                    = "address"
 	CLICollectInterval            = "collect-interval"
 	CLIKubernetes                 = "kubernetes"
+	CLIKubernetesEnablePodLabels  = "kubernetes-enable-pod-labels"
 	CLIKubernetesGPUIDType        = "kubernetes-gpu-id-type"
 	CLIUseOldNamespace            = "use-old-namespace"
 	CLIRemoteHEInfo               = "remote-hostengine-info"
@@ -163,6 +164,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   "localhost:5555",
 			Usage:   "Connect to remote hostengine at <HOST>:<PORT>",
 			EnvVars: []string{"DCGM_REMOTE_HOSTENGINE_INFO"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIKubernetesEnablePodLabels,
+			Value:   false,
+			Usage:   "Enable kubernetes pod labels in metrics. This parameter is effective only when the '--kubernetes' option is set to 'true'.",
+			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"},
 		},
 		&cli.StringFlag{
 			Name:  CLIKubernetesGPUIDType,
@@ -638,6 +645,7 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		Address:                    c.String(CLIAddress),
 		CollectInterval:            c.Int(CLICollectInterval),
 		Kubernetes:                 c.Bool(CLIKubernetes),
+		KubernetesEnablePodLabels:  c.Bool(CLIKubernetesEnablePodLabels),
 		KubernetesGPUIdType:        appconfig.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
 		CollectDCP:                 true,
 		UseOldNamespace:            c.Bool(CLIUseOldNamespace),

--- a/tests/e2e/e2e_actions_test.go
+++ b/tests/e2e/e2e_actions_test.go
@@ -78,6 +78,30 @@ func shouldCreateHelmClient(config *rest.Config) *framework.HelmClient {
 	return helmClient
 }
 
+func shouldInstallHelmChart(ctx context.Context, helmClient *framework.HelmClient, additionalValues []string) string {
+	By(fmt.Sprintf("Helm chart installation: %q chart started.", testContext.chart))
+
+	// Get default values and merge with additional ones
+	values := getDefaultHelmValues()
+	if len(additionalValues) > 0 {
+		values = append(values, additionalValues...)
+	}
+
+	helmReleaseName, err := helmClient.Install(ctx, framework.HelmChartOptions{
+		CleanupOnFail: true,
+		GenerateName:  true,
+		Timeout:       5 * time.Minute,
+		Wait:          true,
+		DryRun:        false,
+	}, framework.WithValues(values...))
+	Expect(err).ShouldNot(HaveOccurred(), "Helm chart installation: %q chart failed with error: %v", testContext.chart, err)
+
+	By(fmt.Sprintf("Helm chart installation: %q completed.", testContext.chart))
+	By(fmt.Sprintf("Helm chart installation: new %q release name.", helmReleaseName))
+
+	return helmReleaseName
+}
+
 func shouldUninstallHelmChart(helmClient *framework.HelmClient, helmReleaseName string) {
 	if helmClient != nil && helmReleaseName != "" {
 		By(fmt.Sprintf("Helm chart uninstall: release %q of the helm chart: %q started.",
@@ -109,11 +133,21 @@ func shouldDeleteNamespace(ctx context.Context, kubeClient *framework.KubeClient
 	if kubeClient != nil {
 		err := kubeClient.DeleteNamespace(ctx, testContext.namespace)
 		if err != nil {
-			Fail(fmt.Sprintf("Namespace deletion: Failed to delete namespace %q with error: %v", testContext.namespace,
-				err))
+			Fail(fmt.Sprintf("Namespace deletion: Failed to delete namespace %q with error: %v", testContext.namespace, err))
 		} else {
-			By(fmt.Sprintf("Namespace deletion: %q namespace completed.\n", testContext.namespace))
+			By(fmt.Sprintf("Namespace deletion: %q deletion initiated.", testContext.namespace))
 		}
+
+		By(fmt.Sprintf("Namespace deletion: %q waiting for completion.", testContext.namespace))
+
+		Eventually(func() bool {
+			// Try to list pods in the namespace - if namespace is gone, this will fail
+			_, err := kubeClient.GetPodsByLabel(ctx, testContext.namespace, map[string]string{})
+			return err != nil // True if namespace no longer exists
+		}).WithTimeout(2*time.Minute).WithPolling(5*time.Second).Should(BeTrue(),
+			fmt.Sprintf("Namespace deletion: Namespace %q was not deleted within the timeout period.", testContext.namespace))
+
+		By(fmt.Sprintf("Namespace deletion: %q namespace fully deleted.", testContext.namespace))
 	}
 }
 
@@ -199,4 +233,59 @@ func shouldCheckIfPodIsReady(ctx context.Context, kubeClient *framework.KubeClie
 		return isReady
 	}).WithPolling(time.Second).Within(15 * time.Minute).WithContext(ctx).Should(BeTrue())
 	By("Checking pod status: completed")
+}
+
+func shouldCreateWorkloadPod(ctx context.Context, kubeClient *framework.KubeClient, labels map[string]string) {
+	By("Workload pod creation: started")
+
+	workloadPod, err := kubeClient.CreatePod(ctx,
+		testContext.namespace,
+		labels,
+		workloadPodName,
+		workloadContainerName,
+		workloadImage,
+		testContext.runtimeClass,
+	)
+
+	Expect(err).ShouldNot(HaveOccurred(),
+		"Workload pod creation: Failed create workload pod with err: %v", err)
+	Eventually(func(ctx context.Context) bool {
+		isReady, err := kubeClient.CheckPodStatus(ctx,
+			testContext.namespace,
+			workloadPod.Name, func(namespace, podName string, status corev1.PodStatus) (bool, error) {
+				return status.Phase == corev1.PodSucceeded, nil
+			})
+		if err != nil {
+			Fail(fmt.Sprintf("Workload pod creation: Checking pod status: Failed with error: %v", err))
+		}
+
+		return isReady
+	}).WithPolling(time.Second).Within(15 * time.Minute).WithContext(ctx).Should(BeTrue())
+
+	By("Workload pod creation: completed")
+}
+
+func shouldReadMetrics(ctx context.Context, kubeClient *framework.KubeClient, dcgmExpPod *corev1.Pod, dcgmExporterPort uint) []byte {
+	By("Read metrics: started")
+
+	var metricsResponse []byte
+
+	Eventually(func(ctx context.Context) bool {
+		var err error
+
+		metricsResponse, err = kubeClient.DoHTTPRequest(ctx,
+			testContext.namespace,
+			dcgmExpPod.Name,
+			dcgmExporterPort,
+			"metrics")
+		if err != nil {
+			Fail(fmt.Sprintf("Read metrics: Failed with error: %v", err))
+		}
+
+		return len(metricsResponse) > 0
+	}).WithPolling(time.Second).Within(time.Minute).WithContext(ctx).Should(BeTrue())
+
+	By("Read metrics: completed")
+
+	return metricsResponse
 }

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -18,10 +18,16 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/common/expfmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/NVIDIA/dcgm-exporter/tests/e2e/internal/framework"
 )
@@ -111,5 +117,135 @@ var _ = Describe("dcgm-exporter-e2e-suite", func() {
 		VerifyHelmConfigurationWhenTLSEnabled(kubeClient, helmClient, testRunLabels)
 
 		VerifyHelmConfigurationWhenHttpBasicAuthEnabled(kubeClient, helmClient, testRunLabels)
+	})
+
+	Context("DCGM exporter with pod labels collection enabled", Ordered, func() {
+		var (
+			kubeClient      *framework.KubeClient
+			helmClient      *framework.HelmClient
+			helmReleaseName string
+			dcgmExpPod      *corev1.Pod
+			customLabels    = map[string]string{
+				"valid_key":       "value-valid",
+				"key-with-dashes": "value-dashes",
+				"key.with.dots":   "value-dots",
+			}
+			labelMap        = map[string]string{dcgmExporterPodNameLabel: dcgmExporterPodNameLabelValue}
+			metricsResponse []byte
+			testRunLabels   = map[string]string{
+				e2eRunIDLabel: runID.String(),
+			}
+		)
+
+		BeforeAll(func(ctx context.Context) {
+			if testContext.kubeconfig == "" {
+				_, _ = fmt.Fprintln(GinkgoWriter, "kubeconfig parameter is empty. Defaulting to ~/.kube/config")
+			}
+
+			if len(testContext.chart) == 0 {
+				Fail("chart parameter is empty")
+			}
+
+			shouldResolvePath()
+			kubeConfigShouldExists()
+
+			k8sConfig := shouldCreateK8SConfig()
+			kubeClient = shouldCreateKubeClient(k8sConfig)
+			helmClient = shouldCreateHelmClient(k8sConfig)
+
+			// Create namespace for pod labels test
+			shouldCreateNamespace(ctx, kubeClient, testRunLabels)
+		})
+
+		AfterAll(func(ctx context.Context) {
+			if testContext.noCleanup {
+				_, _ = fmt.Fprintln(GinkgoWriter, "Clean up: skipped")
+				return
+			}
+
+			By("Starting cleanup for DCGM exporter with pod labels")
+
+			shouldUninstallHelmChart(helmClient, helmReleaseName)
+			shouldCleanupHelmClient(helmClient)
+			shouldDeleteNamespace(ctx, kubeClient)
+
+			By("Cleanup completed")
+		})
+
+		It("should install dcgm-exporter helm chart with pod labels enabled", func(ctx context.Context) {
+			helmReleaseName = shouldInstallHelmChart(ctx, helmClient, []string{
+				"arguments={--kubernetes-enable-pod-labels}",
+			})
+		})
+
+		It("should create dcgm-exporter pod", func(ctx context.Context) {
+			dcgmExpPod = shouldCheckIfPodCreated(ctx, kubeClient, labelMap)
+		})
+
+		It("should ensure that the dcgm-exporter pod is ready", func(ctx context.Context) {
+			shouldCheckIfPodIsReady(ctx, kubeClient, dcgmExpPod.Namespace, dcgmExpPod.Name)
+		})
+
+		It("should create a workload pod with custom labels", func(ctx context.Context) {
+			shouldCreateWorkloadPod(ctx, kubeClient, customLabels)
+		})
+
+		It("should wait for metrics to be collected", func() {
+			By("Waiting 30 seconds for metrics collection")
+			time.Sleep(30 * time.Second)
+		})
+
+		It("should read metrics from dcgm-exporter", func(ctx context.Context) {
+			metricsResponse = shouldReadMetrics(ctx, kubeClient, dcgmExpPod, dcgmExporterPort)
+			Expect(metricsResponse).ShouldNot(BeEmpty(), "Metrics response should not be empty")
+		})
+
+		It("should verify metrics contain sanitized pod labels", func(ctx context.Context) {
+			By("Parsing and verifying metrics contain custom pod labels")
+
+			// Parse metrics
+			var parser expfmt.TextParser
+			metricFamilies, err := parser.TextToMetricFamilies(bytes.NewReader(metricsResponse))
+			Expect(err).ShouldNot(HaveOccurred(), "Error parsing metrics")
+			Expect(metricFamilies).ShouldNot(BeEmpty(), "No metrics found")
+
+			// Expected sanitized label mappings
+			expectedSanitizedLabels := map[string]string{
+				"valid_key":       "value-valid",  // no change needed
+				"key_with_dashes": "value-dashes", // dashes become underscores
+				"key_with_dots":   "value-dots",   // dots become underscores
+			}
+
+			labelsFound := map[string]bool{}
+
+			// Search for sanitized labels in metrics
+			for _, metricFamily := range metricFamilies {
+				for _, metric := range metricFamily.GetMetric() {
+					for _, label := range metric.Label {
+						labelName := ptr.Deref(label.Name, "")
+						labelValue := ptr.Deref(label.Value, "")
+
+						if expectedValue, exists := expectedSanitizedLabels[labelName]; exists {
+							Expect(labelValue).Should(
+								Equal(expectedValue),
+								"Expected sanitized label %q to have value %q, but got %q",
+								labelName, expectedValue, labelValue,
+							)
+							labelsFound[labelName] = true
+						}
+					}
+				}
+			}
+
+			// Verify all expected labels were found
+			for expectedLabel := range expectedSanitizedLabels {
+				Expect(labelsFound[expectedLabel]).Should(
+					BeTrue(),
+					"Expected to find sanitized label %q in metrics", expectedLabel,
+				)
+			}
+
+			By("Pod labels verified successfully in metrics")
+		})
 	})
 })

--- a/tests/e2e/internal/framework/kube.go
+++ b/tests/e2e/internal/framework/kube.go
@@ -78,6 +78,11 @@ func (c *KubeClient) CreateNamespace(
 	return c.client.CoreV1().Namespaces().Create(ctx, namespaceObj, metav1.CreateOptions{})
 }
 
+// GetNamespace checks if a namespace exists and returns its details
+func (c *KubeClient) GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
+	return c.client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+}
+
 // DeleteNamespace deletes the namespace
 func (c *KubeClient) DeleteNamespace(
 	ctx context.Context,


### PR DESCRIPTION
## Summary

Adds opt-in Kubernetes pod label support to dcgm-exporter, enabling GPU metrics to be enriched with labels from pods using the resources. This allows tracking GPU usage by application, implementing chargeback, and debugging performance issues at the workload level.

We have been successfully running these changes in production since the end of December 2024, and it's long overdue that we share this back with the community.

## Implementation

Extends the existing `PodMapper` to fetch pod labels via the Kubernetes API and enrich GPU metrics with sanitized pod labels. Includes caching to minimize API server load.

### Key Features

* **Opt-in:** Disabled by default
* **Cached:** Prevents redundant API calls
* **RBAC integrated:** Conditional `ClusterRole`/`ClusterRoleBinding`
* **Backward compatible:** Existing metrics unchanged

**Configuration**

```yaml
kubernetes:
  enablePodLabels: true
  rbac:
    create: true
```

### Future Optimizations

The kubelet API could give faster, more scalable access to pod info, but it’s not part of the stable public interface. Currently, we rely on the Kubernetes API server, which incurs some overhead but benefits from caching. In the future, we may consider using the kubelet directly, although this approach comes with trade-offs regarding security and long-term support.

Fixes #423