### PR TITLE
Kubernetes Pod UID Support

### DIFF
--- a/deployment/templates/clusterrole.yaml
+++ b/deployment/templates/clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
+{{- if or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deployment/templates/clusterrolebinding.yaml
+++ b/deployment/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if or (and .Values.kubernetes.enablePodLabels .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
+{{- if or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -130,6 +130,10 @@ spec:
         - name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"
           value: "true"
         {{- end }}
+        {{- if .Values.kubernetes.enablePodUID }}
+        - name: "DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID"
+          value: "true"
+        {{- end }}
         - name: "DCGM_EXPORTER_LISTEN"
           value: "{{ .Values.service.address }}"
         - name: NODE_NAME

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -206,9 +206,14 @@ kubernetes:
   # This requires cluster-level read permissions to pods
   enablePodLabels: false
 
+  # Enable Kubernetes pod UID in metrics
+  # When enabled, metrics will include the pod UID as an attribute for the pods that are using the GPUs
+  # This requires cluster-level read permissions to pods
+  enablePodUID: false
+
   # RBAC settings for Kubernetes integration
   rbac:
-    # Automatically creates ClusterRole and ClusterRoleBinding for pod access when enablePodLabels is true
+    # Automatically creates ClusterRole and ClusterRoleBinding for pod access when enablePodLabels or enablePodUID is true
     # Set to false if you want to manage RBAC resources manually
     create: true
 

--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -42,6 +42,7 @@ type Config struct {
 	CollectInterval            int
 	Kubernetes                 bool
 	KubernetesEnablePodLabels  bool
+	KubernetesEnablePodUID     bool
 	KubernetesGPUIdType        KubernetesGPUIDType
 	CollectDCP                 bool
 	UseOldNamespace            bool

--- a/internal/pkg/transformation/const.go
+++ b/internal/pkg/transformation/const.go
@@ -21,6 +21,7 @@ const (
 	podAttribute       = "pod"
 	namespaceAttribute = "namespace"
 	containerAttribute = "container"
+	uidAttribute       = "pod_uid"
 	vgpuAttribute      = "vgpu"
 
 	hpcJobAttribute = "hpc_job"

--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -92,7 +92,7 @@ func NewPodMapper(c *appconfig.Config) *PodMapper {
 		Config: c,
 	}
 
-	if !c.KubernetesEnablePodLabels && !c.KubernetesEnableDRA {
+	if !c.KubernetesEnablePodLabels && !c.KubernetesEnablePodUID && !c.KubernetesEnableDRA {
 		return podMapper
 	}
 
@@ -227,6 +227,7 @@ func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo devic
 						metric.Attributes[oldNamespaceAttribute] = pi.Namespace
 						metric.Attributes[oldContainerAttribute] = pi.Container
 					}
+					metric.Attributes[uidAttribute] = pi.UID
 					if pi.VGPU != "" {
 						metric.Attributes[vgpuAttribute] = pi.VGPU
 					}
@@ -264,7 +265,8 @@ func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo devic
 					metrics[counter][j].Attributes[oldNamespaceAttribute] = podInfo.Namespace
 					metrics[counter][j].Attributes[oldContainerAttribute] = podInfo.Container
 				}
-
+				
+				metrics[counter][j].Attributes[uidAttribute] = podInfo.UID
 				maps.Copy(metrics[counter][j].Labels, podInfo.Labels)
 
 				if len(podInfo.DynamicResources) > 0 {
@@ -337,10 +339,10 @@ func getSharedGPU(deviceID string) (string, bool) {
 // GPU states.
 func (p *PodMapper) toDeviceToSharingPods(devicePods *podresourcesapi.ListPodResourcesResponse, deviceInfo deviceinfo.Provider) map[string][]PodInfo {
 	deviceToPodsMap := make(map[string][]PodInfo)
-	labelCache := make(map[string]map[string]string) // Cache to avoid duplicate API calls
+	metadataCache := make(map[string]PodMetadata) // Cache to avoid duplicate API calls
 
 	p.iterateGPUDevices(devicePods, func(pod *podresourcesapi.PodResources, container *podresourcesapi.ContainerResources, device *podresourcesapi.ContainerDevices) {
-		podInfo := p.createPodInfo(pod, container, labelCache)
+		podInfo := p.createPodInfo(pod, container, metadataCache)
 
 		for _, deviceID := range device.GetDeviceIds() {
 			if vgpu, ok := getSharedGPU(deviceID); ok {
@@ -389,7 +391,7 @@ func (p *PodMapper) toDeviceToPod(
 	devicePods *podresourcesapi.ListPodResourcesResponse, deviceInfo deviceinfo.Provider,
 ) map[string]PodInfo {
 	deviceToPodMap := make(map[string]PodInfo)
-	labelCache := make(map[string]map[string]string) // Cache to avoid duplicate API calls
+	metadataCache := make(map[string]PodMetadata) // Cache to avoid duplicate API calls
 
 	slog.Debug("Processing pod resources", "totalPods", len(devicePods.GetPodResources()))
 
@@ -429,7 +431,7 @@ func (p *PodMapper) toDeviceToPod(
 					"containerName", container.GetName())
 			}
 
-			podInfo := p.createPodInfo(pod, container, labelCache)
+			podInfo := p.createPodInfo(pod, container, metadataCache)
 			slog.Debug("Created pod info",
 				"podInfo", fmt.Sprintf("%+v", podInfo),
 				"podName", pod.GetName(),
@@ -631,40 +633,64 @@ func (p *PodMapper) toDeviceToPod(
 	return deviceToPodMap
 }
 
-// createPodInfo creates a PodInfo struct with labels if enabled
-func (p *PodMapper) createPodInfo(pod *podresourcesapi.PodResources, container *podresourcesapi.ContainerResources, labelCache map[string]map[string]string) PodInfo {
+// createPodInfo creates a PodInfo struct with metadata if enabled
+func (p *PodMapper) createPodInfo(pod *podresourcesapi.PodResources, container *podresourcesapi.ContainerResources, metadataCache map[string]PodMetadata) PodInfo {
 	labels := map[string]string{}
-	if p.Config.KubernetesEnablePodLabels {
-		// Use cache key combining namespace and name
-		cacheKey := pod.GetNamespace() + "/" + pod.GetName()
-		if cachedLabels, exists := labelCache[cacheKey]; exists {
-			labels = cachedLabels
-		} else {
-			// Only make API call if not in cache
-			if podLabels, err := p.getPodLabels(pod.GetNamespace(), pod.GetName()); err != nil {
-				slog.Warn("Couldn't get pod labels",
-					"pod", pod.GetName(),
-					"namespace", pod.GetNamespace(),
-					"error", err)
-				labelCache[cacheKey] = map[string]string{} // Cache empty result to avoid repeated failures
-			} else {
-				labels = podLabels
-				labelCache[cacheKey] = podLabels // Cache successful result
+	uid := ""
+	cacheKey := pod.GetNamespace() + "/" + pod.GetName()
+
+	// Check if we have cached metadata
+	cachedMetadata, hasCache := metadataCache[cacheKey]
+
+	// Determine if we need labels
+	needLabels := p.Config.KubernetesEnablePodLabels && (cachedMetadata.Labels == nil)
+
+	// Determine if we need UID
+	needUID := p.Config.KubernetesEnablePodUID && cachedMetadata.UID == ""
+
+	// Only make API call if we need something that's not cached
+	if needLabels || needUID {
+		if podMetadata, err := p.getPodMetadata(pod.GetNamespace(), pod.GetName()); err != nil {
+			slog.Warn("Couldn't get pod metadata",
+				"pod", pod.GetName(),
+				"namespace", pod.GetNamespace(),
+				"error", err)
+			// Cache empty result to avoid repeated failures, but preserve existing cache data
+			if !hasCache {
+				metadataCache[cacheKey] = PodMetadata{}
 			}
+		} else {
+			// Update cache with new data, preserving existing data if we didn't fetch it
+			if needLabels {
+				cachedMetadata.Labels = podMetadata.Labels
+			}
+			if needUID {
+				cachedMetadata.UID = podMetadata.UID
+			}
+			metadataCache[cacheKey] = cachedMetadata
 		}
+	}
+
+	// Extract the data we need based on config flags
+	if p.Config.KubernetesEnablePodLabels {
+		labels = cachedMetadata.Labels
+	}
+	if p.Config.KubernetesEnablePodUID {
+		uid = cachedMetadata.UID
 	}
 
 	return PodInfo{
 		Name:      pod.GetName(),
 		Namespace: pod.GetNamespace(),
 		Container: container.GetName(),
+		UID:       uid,
 		Labels:    labels,
 	}
 }
 
-// getPodLabels fetches labels from a Kubernetes pod via the API server.
+// getPodMetadata fetches metadata (labels and UID) from a Kubernetes pod via the API server.
 // It sanitizes label names to ensure they are valid for Prometheus metrics.
-func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, error) {
+func (p *PodMapper) getPodMetadata(namespace, podName string) (*PodMetadata, error) {
 	if p.Client == nil {
 		return nil, fmt.Errorf("kubernetes client is not initialized")
 	}
@@ -678,11 +704,14 @@ func (p *PodMapper) getPodLabels(namespace, podName string) (map[string]string, 
 	}
 
 	// Sanitize label names
-	sanitizedLabels := make((map[string]string), len(pod.Labels))
+	sanitizedLabels := make(map[string]string, len(pod.Labels))
 	for k, v := range pod.Labels {
 		sanitizedKey := utils.SanitizeLabelName(k)
 		sanitizedLabels[sanitizedKey] = v
 	}
 
-	return sanitizedLabels, nil
+	return &PodMetadata{
+		UID:    string(pod.UID),
+		Labels: sanitizedLabels,
+	}, nil
 }

--- a/internal/pkg/transformation/types.go
+++ b/internal/pkg/transformation/types.go
@@ -46,6 +46,7 @@ type PodInfo struct {
 	Name             string
 	Namespace        string
 	Container        string
+	UID              string
 	VGPU             string
 	Labels           map[string]string
 	DynamicResources []DynamicResourceInfo
@@ -57,6 +58,12 @@ type DRAResourceSliceManager struct {
 	cancelContext context.CancelFunc
 	mu            sync.RWMutex
 	deviceToUUID  map[string]string
+}
+
+// PodMetadata holds pod metadata from API server
+type PodMetadata struct {
+	UID    string
+	Labels map[string]string
 }
 
 type DynamicResourceInfo struct {

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -70,6 +70,7 @@ const (
 	CLICollectInterval            = "collect-interval"
 	CLIKubernetes                 = "kubernetes"
 	CLIKubernetesEnablePodLabels  = "kubernetes-enable-pod-labels"
+	CLIKubernetesEnablePodUID     = "kubernetes-enable-pod-uid"
 	CLIKubernetesGPUIDType        = "kubernetes-gpu-id-type"
 	CLIUseOldNamespace            = "use-old-namespace"
 	CLIRemoteHEInfo               = "remote-hostengine-info"
@@ -175,6 +176,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   false,
 			Usage:   "Enable kubernetes pod labels in metrics. This parameter is effective only when the '--kubernetes' option is set to 'true'.",
 			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_LABELS"},
+		},
+		&cli.BoolFlag{
+			Name:    CLIKubernetesEnablePodUID,
+			Value:   false,
+			Usage:   "Enable kubernetes pod UID in metrics. This parameter is effective only when the '--kubernetes' option is set to 'true'.",
+			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID"},
 		},
 		&cli.StringFlag{
 			Name:  CLIKubernetesGPUIDType,
@@ -680,6 +687,7 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		CollectInterval:            c.Int(CLICollectInterval),
 		Kubernetes:                 c.Bool(CLIKubernetes),
 		KubernetesEnablePodLabels:  c.Bool(CLIKubernetesEnablePodLabels),
+		KubernetesEnablePodUID:     c.Bool(CLIKubernetesEnablePodUID),
 		KubernetesGPUIdType:        appconfig.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
 		CollectDCP:                 true,
 		UseOldNamespace:            c.Bool(CLIUseOldNamespace),


### PR DESCRIPTION
 # Kubernetes Pod UID Support

  ## Add Kubernetes pod UID support

  This commit adds an opt-in Kubernetes pod UID support to dcgm-exporter, enabling GPU metrics to be enriched with pod UID attributes from the pods that are using the resources. The implementation leverages the existing unified metadata caching system to minimize API server load and optimize performance.

  **Key Changes:**

  * Extended existing PodMapper with UID collection and caching capabilities
  * Integrated pod UIDs into GPU metrics as `pod_uid` attribute
  * Added `DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID` environment variable
  * Unified metadata caching for both labels and UIDs with optimized API calls
  * Comprehensive test coverage for UID functionality

  The pod UID is automatically included in GPU metrics when the feature is enabled, providing better observability and correlation between workloads and resource usage. This complements the existing pod labels feature.

  ## Add RBAC for Kubernetes pod UID integration

  This change extends the existing RBAC support to include pod UID collection alongside the pod labels feature. The implementation reuses the same `ClusterRole` and `ClusterRoleBinding` resources when either Kubernetes pod labels or pod UID features are enabled, ensuring RBAC resources are only created when metadata collection features are actually needed.

  The configuration includes `kubernetes.enablePodUID` to control the UID feature, building on the existing `kubernetes.rbac.create` setting for automatic RBAC resource management. When enabled, the daemonset receives the `DCGM_EXPORTER_KUBERNETES_ENABLE_POD_UID` environment variable to activate pod UID collection at runtime.

  **RBAC Changes:**
  * Updated conditional logic in ClusterRole and ClusterRoleBinding templates
  * Extended DaemonSet environment variables for UID feature
  * Added `kubernetes.enablePodUID` configuration option to values.yaml
  * Updated documentation to reflect support for both labels and UID features

  The changes maintain backwards compatibility and follow the same conditional patterns established by the pod labels feature, ensuring consistent behavior across both metadata collection capabilities.

Signed-off-by: Andrew Leung <andrew.leung@uber.com>