### PR TITLE
fix(hpc ) Add a judgment on whether jobs is empty

### DIFF
--- a/internal/pkg/transformation/hpc.go
+++ b/internal/pkg/transformation/hpc.go
@@ -81,7 +81,7 @@ func (p *hpcMapper) Process(metrics collector.MetricsByCounter, _ deviceinfo.Pro
 		var modifiedMetrics []collector.Metric
 		for _, metric := range metrics[counter] {
 			jobs, exists := gpuToJobMap[metric.GPU]
-			if exists {
+			if exists && len(jobs) != 0 {
 				for _, job := range jobs {
 					modifiedMetric, err := utils.DeepCopy(metric)
 					if err != nil {


### PR DESCRIPTION
I enabled the 'hpc-job-mapping-dir' parameter, which specifies the directory '/tmp/hpc_mapper_dir'. Under this directory, several GPU files will be generated. However, since some Gpus are idle and no tasks are running on them, the GPU files are empty. Here, the code only checks whether the file exists and does not check jobs. As a result, when the file exists but jobs are empty, it will enter if instead of loloop jobs, thus preventing the collection of idle GPU information


<img width="1156" height="970" alt="2ee6c95c69eb75ddb35a1a670f46ca4" src="https://github.com/user-attachments/assets/bce0b423-8872-406b-8ed7-1a0b981d8d0d" />

I have eight GPU cards

<img width="1911" height="186" alt="ef3a20a1871515eb7cda6e2c1cc34a7" src="https://github.com/user-attachments/assets/942fbc66-5ba2-4e2d-9367-e3e67429e03e" />
However, since two cards were idle and there was no job id, the gpu modification information was not reported