### PR TITLE
(helm chart) Make priorityClassName optional

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -45,7 +45,9 @@ spec:
       {{- if .Values.runtimeClassName }}
       runtimeClassName: {{ .Values.runtimeClassName }}
       {{- end }}
-      priorityClassName: {{ .Values.priorityClassName | default "system-node-critical" }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: {{ .Values.hostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -51,6 +51,9 @@ namespaceOverride: ""
 
 # Defines the runtime class that will be used by the pod
 runtimeClassName: ""
+# Defines the priority class that will be used by the pod
+priorityClassName: "system-node-critical"
+
 # Defines serviceAccount names for components.
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
The chart currently always sets priorityClassName on the DaemonSet by using an inline default-- and not actually accepting the value as input (which seems like a problem even if you do want to require it).

Keeping the same default, I'm allowing priorityClassName to be omitted, which simplifies the process of deploying this in a non-standard namespace.

This is basically a copy of #438 , but I squashed and signed (per CONTRIBUTING.md).