### PR TITLE
feat(go.mod): update go-dcgm dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/NVIDIA/go-dcgm v0.0.0-20250731202351-984cbc9b6270
+	github.com/NVIDIA/go-dcgm v0.0.0-20250814030002-9097b5c5a1bf
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/bits-and-blooms/bitset v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/NVIDIA/go-dcgm v0.0.0-20250731202351-984cbc9b6270 h1:Qz7CJ3PCn/qRj/1jr3qNqmg2zDleO6RXc6txcp7BHFI=
 github.com/NVIDIA/go-dcgm v0.0.0-20250731202351-984cbc9b6270/go.mod h1:cA0Bv7+JtAd8sqCCZizhAQjj4+Z47x/d8KD60iYBT+g=
+github.com/NVIDIA/go-dcgm v0.0.0-20250814030002-9097b5c5a1bf h1:WtJsvMPj/aBvo+lD4tAxxcObtOJ8U5HUp1I5b2HP9ls=
+github.com/NVIDIA/go-dcgm v0.0.0-20250814030002-9097b5c5a1bf/go.mod h1:cA0Bv7+JtAd8sqCCZizhAQjj4+Z47x/d8KD60iYBT+g=
 github.com/NVIDIA/go-nvml v0.12.4-1 h1:WKUvqshhWSNTfm47ETRhv0A0zJyr1ncCuHiXwoTrBEc=
 github.com/NVIDIA/go-nvml v0.12.4-1/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
this PR pulls in the updated go-dcgm bindings from https://github.com/NVIDIA/go-dcgm/pull/91 

tested in my environment and properly outputting the new field

```
% curl localhost:9400/metrics | grep -i DCGM_FI_DEV_THRESHOLD_SRM
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--   100 49264    0 49264    0     0   145k      0 --:--:-- --:--:-- --:--:--  145k
# HELP DCGM_FI_DEV_THRESHOLD_SRM bool to show if gpu srm threshold exceeded
# TYPE DCGM_FI_DEV_THRESHOLD_SRM gauge
DCGM_FI_DEV_THRESHOLD_SRM{gpu="0",UUID="redacted",pci_bus_id="00000008:06:00.0",device="nvidia0",modelName="NVIDIA Graphics Device",Hostname="redacted",DCGM_FI_DEV_SERIAL="redacted",DCGM_FI_DEV_VBIOS_VERSION="97.10.3E.00.05"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="1",UUID="redacted",pci_bus_id="00000009:06:00.0",device="nvidia1",modelName="NVIDIA Graphics Device",Hostname="redacted",DCGM_FI_DEV_SERIAL="redacted",DCGM_FI_DEV_VBIOS_VERSION="97.10.3E.00.05"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="2",UUID="redacted",pci_bus_id="00000018:06:00.0",device="nvidia2",modelName="NVIDIA Graphics Device",Hostname="redacted",DCGM_FI_DEV_SERIAL="redacted",DCGM_FI_DEV_VBIOS_VERSION="97.10.3E.00.05"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="3",UUID="redacted",pci_bus_id="00000019:06:00.0",device="nvidia3",modelName="NVIDIA Graphics Device",Hostname="redacted",DCGM_FI_DEV_SERIAL="redacted",DCGM_FI_DEV_VBIOS_VERSION="97.10.3E.00.05"} 0
```