### PR TITLE
Fix PodMetadata type issue resulting from merge conflict

### DIFF
--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -375,7 +375,7 @@ func getSharedGPU(deviceID string) (string, bool) {
 
 func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourcesResponse) map[string][]PodInfo {
 	deviceToPodsMap := make(map[string][]PodInfo)
-	labelCache := make(map[string]map[string]string) // Cache to avoid duplicate API calls
+	labelCache := make(map[string]PodMetadata) // Cache to avoid duplicate API calls
 
 	slog.Debug("Processing pod dynamic resources", "totalPods", len(devicePods.GetPodResources()))
 	// Track pod+namespace+container combinations per device


### PR DESCRIPTION
 # Fix: Resolve PodMetadata type mismatch from merge conflict

  ## Summary

  This PR fixes a compilation error introduced by a merge conflict between PR #531 (Kubernetes Pod UID Support) and PR #535 (DCGM-Exporter 4.3.1-4.4.0). The error manifests as a type mismatch where `labelCache` variable in the `toDeviceToPodsDRA` function has type `map[string]map[string]string` but function `createPodInfo` expects `map[string]PodMetadata`.

  ## Root Cause

  The issue was caused by concurrent development on the same code area. PR #535 was developed before PR #531's changes and used the old `labelCache` type (`map[string]map[string]string`) while calling the new `createPodInfo` function signature.

  ## Changes Made

  - **File**: `internal/pkg/transformation/kubernetes.go:378`
  - **Change**: Updated `labelCache` type in `toDeviceToPodsDRA` function from `map[string]map[string]string` to `map[string]PodMetadata`
  - **Reason**: Ensures type consistency with the `createPodInfo` function signature that was updated in PR #531

  ## Related PRs

  - **Introduced metadata changes**: PR #531 - Kubernetes Pod UID Support
  - **Introduced DRA function**: PR #535 - DCGM-Exporter 4.3.1-4.4.0 (fix dra labels when gpu is shared)
  - **Resolves**: Type mismatch between concurrent development branches