### PR TITLE
feat: add disable startup validate flag

### DIFF
--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -69,4 +69,5 @@ type Config struct {
 	KubernetesVirtualGPUs      bool
 	DumpConfig                 DumpConfig // Configuration for file-based dumps
 	KubernetesEnableDRA        bool
+	DisableStartupValidate     bool
 }


### PR DESCRIPTION
Fixes #553.

For minimal or debug environments, where ldconfig-based checking is not necessary, e.g. debugging a fix in a dev container or relying on standard library paths, we propose to add a flag that skips the prerequisite validation checks.