### PR TITLE
Follow FHS convention for logging:

### DIFF
--- a/packaging/config-files/systemd/nvidia-dcgm-exporter.service
+++ b/packaging/config-files/systemd/nvidia-dcgm-exporter.service
@@ -22,8 +22,8 @@ After=nvidia-dcgm.service
 User=root
 PrivateTmp=false
 
-StandardOutput=append:/var/dcgm-exporter.log
-StandardError=append:/var/dcgm-exporter.log
+StandardOutput=append:/var/log/dcgm-exporter.log
+StandardError=append:/var/log/dcgm-exporter.log
 
 ExecStart=/usr/bin/dcgm-exporter -f /etc/dcgm-exporter/default-counters.csv
 


### PR DESCRIPTION
Log files should be stored in /var/log, adjusted StandardOutput and StandardError in systemd unit file to meet Filesystem Hierarchy Standard conventions.