### PR TITLE
feat(dcgm-exporter): add option to fail on nvml provider init error

### DIFF
--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -57,6 +57,7 @@ type Config struct {
 	MetricGroups               []dcgm.MetricGroup
 	WebSystemdSocket           bool
 	WebConfigFile              string
+	FailOnNVMLInitError        bool
 	XIDCountWindowSize         int
 	ReplaceBlanksInModelName   bool
 	Debug                      bool

--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -57,7 +57,6 @@ type Config struct {
 	MetricGroups               []dcgm.MetricGroup
 	WebSystemdSocket           bool
 	WebConfigFile              string
-	FailOnNVMLInitError        bool
 	XIDCountWindowSize         int
 	ReplaceBlanksInModelName   bool
 	Debug                      bool

--- a/internal/pkg/nvmlprovider/provider.go
+++ b/internal/pkg/nvmlprovider/provider.go
@@ -35,8 +35,13 @@ type MIGDeviceInfo struct {
 var nvmlInterface NVML
 
 // Initialize sets up the Singleton NVML interface.
-func Initialize() {
-	nvmlInterface = newNVMLProvider()
+func Initialize() error {
+	var err error
+	nvmlInterface, err = newNVMLProvider()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // reset clears the current NVML interface instance.
@@ -59,11 +64,11 @@ type nvmlProvider struct {
 	initialized bool
 }
 
-func newNVMLProvider() NVML {
+func newNVMLProvider() (NVML, error) {
 	// Check if a NVML client already exists and return it if so.
 	if Client() != nil && Client().(nvmlProvider).initialized {
 		slog.Info("NVML already initialized.")
-		return Client()
+		return Client(), nil
 	}
 
 	slog.Info("Attempting to initialize NVML library.")
@@ -71,10 +76,10 @@ func newNVMLProvider() NVML {
 	if ret != nvml.SUCCESS {
 		err := errors.New(nvml.ErrorString(ret))
 		slog.Error(fmt.Sprintf("Cannot init NVML library; err: %v", err))
-		return nvmlProvider{initialized: false}
+		return nvmlProvider{initialized: false}, err
 	}
 
-	return nvmlProvider{initialized: true}
+	return nvmlProvider{initialized: true}, nil
 }
 
 func (n nvmlProvider) preCheck() error {
@@ -83,6 +88,10 @@ func (n nvmlProvider) preCheck() error {
 	}
 
 	return nil
+}
+
+func (n *nvmlProvider) IsInitialized() bool {
+	return n.initialized
 }
 
 // GetMIGDeviceInfoByID returns information about MIG DEVICE by ID

--- a/internal/pkg/nvmlprovider/provider.go
+++ b/internal/pkg/nvmlprovider/provider.go
@@ -90,10 +90,6 @@ func (n nvmlProvider) preCheck() error {
 	return nil
 }
 
-func (n *nvmlProvider) IsInitialized() bool {
-	return n.initialized
-}
-
 // GetMIGDeviceInfoByID returns information about MIG DEVICE by ID
 func (n nvmlProvider) GetMIGDeviceInfoByID(uuid string) (*MIGDeviceInfo, error) {
 	if err := n.preCheck(); err != nil {

--- a/internal/pkg/nvmlprovider/provider_test.go
+++ b/internal/pkg/nvmlprovider/provider_test.go
@@ -107,9 +107,15 @@ func Test_newNVMLProvider(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var nvmlProvider NVML
+			var err error
+			nvmlProvider, err = newNVMLProvider()
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
 			want := tt.preRunFunc()
 			defer reset()
-			assert.Equalf(t, want, newNVMLProvider(), "Unexpected Output")
+			assert.Equalf(t, want, nvmlProvider, "Unexpected Output")
 		})
 	}
 }

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -82,7 +82,6 @@ const (
 	CLIConfigMapData              = "configmap-data"
 	CLIWebSystemdSocket           = "web-systemd-socket"
 	CLIWebConfigFile              = "web-config-file"
-	CLIFailOnNVMLInitError        = "fail-on-nvml-init-error"
 	CLIXIDCountWindowSize         = "xid-count-window-size"
 	CLIReplaceBlanksInModelName   = "replace-blanks-in-model-name"
 	CLIDebugMode                  = "debug"
@@ -224,12 +223,6 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   "",
 			Usage:   "Web configuration file following webConfig spec: https://github.com/prometheus/exporter-toolkit/blob/master/docs/web-configuration.md.",
 			EnvVars: []string{"DCGM_EXPORTER_WEB_CONFIG_FILE"},
-		},
-		&cli.BoolFlag{
-			Name:    CLIFailOnNVMLInitError,
-			Value:   false,
-			Usage:   "Fail the application if NVML initialization fails",
-			EnvVars: []string{"DCGM_EXPORTER_FAIL_ON_NVML_INIT_ERROR"},
 		},
 		&cli.IntFlag{
 			Name:    CLIXIDCountWindowSize,
@@ -429,7 +422,6 @@ func startDCGMExporter(c *cli.Context) error {
 
 		// Only validate prerequisites if not disabled.
 		if !config.DisableStartupValidate {
-			config.FailOnNVMLInitError = true // enable failure on NVML Init Error
 			err = prerequisites.Validate()
 			if err != nil {
 				return err
@@ -442,7 +434,7 @@ func startDCGMExporter(c *cli.Context) error {
 
 		// Initialize NVML Provider Instance
 		err = nvmlprovider.Initialize()
-		if err != nil && config.FailOnNVMLInitError {
+		if err != nil && !config.DisableStartupValidate {
 			return err // exit if we can't initialize nvml
 		}
 
@@ -721,7 +713,6 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		ConfigMapData:              c.String(CLIConfigMapData),
 		WebSystemdSocket:           c.Bool(CLIWebSystemdSocket),
 		WebConfigFile:              c.String(CLIWebConfigFile),
-		FailOnNVMLInitError:        c.Bool(CLIFailOnNVMLInitError),
 		XIDCountWindowSize:         c.Int(CLIXIDCountWindowSize),
 		ReplaceBlanksInModelName:   c.Bool(CLIReplaceBlanksInModelName),
 		Debug:                      c.Bool(CLIDebugMode),

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -429,6 +429,7 @@ func startDCGMExporter(c *cli.Context) error {
 
 		// Only validate prerequisites if not disabled.
 		if !config.DisableStartupValidate {
+			config.FailOnNVMLInitError = true // enable failure on NVML Init Error
 			err = prerequisites.Validate()
 			if err != nil {
 				return err


### PR DESCRIPTION
this PR adds the option to exit if we are unable to initialize the nvml provider. it has been observed and reported that nvml.Init() periodically fails to initialize the provider, but this error is currently ignored in dcgm-exporter. the result is an exporter that is unable to export gpu metrics, and in my case, exports nothing. the only indication that there has been an issue on startup is visible in the logs.

nvml init issue reported here https://github.com/NVIDIA/go-nvml/issues/164 and here https://github.com/NVIDIA/dcgm-exporter/issues/530