### PR TITLE
Handle uninitialized map in HPC job mapping

### DIFF
--- a/internal/pkg/transformation/hpc.go
+++ b/internal/pkg/transformation/hpc.go
@@ -103,6 +103,10 @@ func (p *hpcMapper) Process(metrics collector.MetricsByCounter, _ deviceinfo.Pro
 							slog.String(logging.ErrorKey, err.Error()))
 						continue
 					}
+					if modifiedMetric.Attributes == nil {
+						slog.Debug("modifiedMetric.Attributes is nil, making an empty map")
+						modifiedMetric.Attributes = make(map[string]string)
+					}
 					modifiedMetric.Attributes[hpcJobAttribute] = job
 					modifiedMetrics = append(modifiedMetrics, modifiedMetric)
 				}


### PR DESCRIPTION
Fixes #560