### PR TITLE
Update golang requirement in integration README

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,7 +2,7 @@
 
 - Machine with NVIDIA GPU
 - Operation system Linux
-- [Golang >= 1.18 installed](https://golang.org/)
+- [Golang >= 1.24 installed](https://golang.org/)
 - [DCGM installed](https://developer.nvidia.com/dcgm)
 
 # Integration Tests


### PR DESCRIPTION
The root README and go.mod specify Go 1.24, but tests/integration/README.md still says 1.18.