### PR TITLE
Fix unbounded memory growth in pod label allowlist cache

### DIFF
--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -45,6 +45,7 @@ type Config struct {
 	KubernetesEnablePodUID           bool
 	KubernetesGPUIdType              KubernetesGPUIDType
 	KubernetesPodLabelAllowlistRegex []string // Regex patterns for filtering pod labels
+	KubernetesPodLabelCacheSize      int      // Maximum number of label keys to cache (<=0 means default size)
 	CollectDCP                       bool
 	UseOldNamespace                  bool
 	UseRemoteHE                      bool

--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -17,6 +17,7 @@
 package transformation
 
 import (
+	"container/list"
 	"context"
 	"fmt"
 	"log/slog"
@@ -88,9 +89,15 @@ func (p *PodMapper) iterateGPUDevices(devicePods *podresourcesapi.ListPodResourc
 func NewPodMapper(c *appconfig.Config) *PodMapper {
 	slog.Info("Kubernetes metrics collection enabled!")
 
+	// Default cache size if not configured
+	cacheSize := c.KubernetesPodLabelCacheSize
+	if cacheSize <= 0 {
+		cacheSize = 150000 // Default: ~18MB for 150k entries (suitable for large cloud clusters)
+	}
+
 	podMapper := &PodMapper{
 		Config:           c,
-		labelFilterCache: newLabelFilterCache(c.KubernetesPodLabelAllowlistRegex),
+		labelFilterCache: newLabelFilterCache(c.KubernetesPodLabelAllowlistRegex, cacheSize),
 	}
 
 	if !c.KubernetesEnablePodLabels && !c.KubernetesEnablePodUID && !c.KubernetesEnableDRA {
@@ -123,15 +130,20 @@ func NewPodMapper(c *appconfig.Config) *PodMapper {
 	return podMapper
 }
 
-// newLabelFilterCache creates a new cache with pre-compiled regex patterns
-func newLabelFilterCache(patterns []string) *LabelFilterCache {
+// newLabelFilterCache creates a new LRU cache with pre-compiled regex patterns
+func newLabelFilterCache(patterns []string, maxSize int) *LabelFilterCache {
 	cache := &LabelFilterCache{
 		enabled: len(patterns) > 0,
+		maxSize: maxSize,
 	}
 
 	if !cache.enabled {
 		return cache
 	}
+
+	// Initialize LRU cache structures
+	cache.cache = make(map[string]*list.Element)
+	cache.lruList = list.New()
 
 	// Pre-compile all regex patterns at initialization time
 	cache.compiledPatterns = make([]*regexp.Regexp, 0, len(patterns))
@@ -154,7 +166,8 @@ func newLabelFilterCache(patterns []string) *LabelFilterCache {
 	} else {
 		slog.Info("Pod label filtering enabled",
 			"patterns", len(cache.compiledPatterns),
-			"originalPatterns", len(patterns))
+			"originalPatterns", len(patterns),
+			"cacheSize", maxSize)
 	}
 
 	return cache
@@ -867,8 +880,8 @@ func (p *PodMapper) getPodMetadata(namespace, podName string) (*PodMetadata, err
 }
 
 // shouldIncludeLabel checks if a label should be included based on the allowlist regex patterns.
-// Uses a two-tier cache to avoid expensive regex matching:
-// 1. Check sync.Map for previously evaluated label keys
+// Uses an LRU cache to avoid expensive regex matching while bounding memory:
+// 1. Check cache for previously evaluated label keys
 // 2. If not cached, evaluate against pre-compiled regex patterns and cache the result
 func (p *PodMapper) shouldIncludeLabel(labelKey string) bool {
 	cache := p.labelFilterCache
@@ -877,8 +890,15 @@ func (p *PodMapper) shouldIncludeLabel(labelKey string) bool {
 		return true
 	}
 
-	if result, ok := cache.allowedLabels.Load(labelKey); ok {
-		return result.(bool)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+
+	// Check if labelKey is in cache
+	if elem, exists := cache.cache[labelKey]; exists {
+		// Cache hit: move to most recently used and return cached value
+		cache.lruList.MoveToFront(elem)
+		entry := elem.Value.(*labelCacheEntry)
+		return entry.value
 	}
 
 	allowed := false
@@ -889,7 +909,24 @@ func (p *PodMapper) shouldIncludeLabel(labelKey string) bool {
 		}
 	}
 
-	cache.allowedLabels.Store(labelKey, allowed)
+	entry := &labelCacheEntry{
+		key:   labelKey,
+		value: allowed,
+	}
+
+	// If cache is at capacity, evict least recently used entry
+	if cache.lruList.Len() >= cache.maxSize {
+		oldest := cache.lruList.Back()
+		if oldest != nil {
+			cache.lruList.Remove(oldest)
+			oldEntry := oldest.Value.(*labelCacheEntry)
+			delete(cache.cache, oldEntry.key)
+		}
+	}
+
+	// Add new entry to front (most recently used)
+	elem := cache.lruList.PushFront(entry)
+	cache.cache[labelKey] = elem
 
 	return allowed
 }

--- a/internal/pkg/transformation/kubernetes_label_filter_test_lru.go
+++ b/internal/pkg/transformation/kubernetes_label_filter_test_lru.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transformation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
+)
+
+// TestLabelFilterCache_LRUEviction tests that the cache properly evicts least recently used entries
+func TestLabelFilterCache_LRUEviction(t *testing.T) {
+	patterns := []string{"^label-.*"} // Match labels starting with "label-"
+	cacheSize := 5
+
+	podMapper := &PodMapper{
+		Config: &appconfig.Config{
+			KubernetesPodLabelAllowlistRegex: patterns,
+		},
+		labelFilterCache: newLabelFilterCache(patterns, cacheSize),
+	}
+
+	cache := podMapper.labelFilterCache
+
+	// Fill cache to capacity
+	for i := 1; i <= cacheSize; i++ {
+		labelKey := fmt.Sprintf("label-%d", i)
+		result := podMapper.shouldIncludeLabel(labelKey)
+		assert.True(t, result, "Label should match pattern")
+	}
+
+	// Verify cache is at capacity
+	cache.mu.Lock()
+	assert.Equal(t, cacheSize, len(cache.cache), "Cache should be at capacity")
+	assert.Equal(t, cacheSize, cache.lruList.Len(), "LRU list should match cache size")
+	cache.mu.Unlock()
+
+	// Access label-3 to make it more recently used
+	podMapper.shouldIncludeLabel("label-3")
+
+	// Add a new label, should evict label-1 (oldest)
+	result := podMapper.shouldIncludeLabel("label-6")
+	assert.True(t, result, "New label should match pattern")
+
+	// Verify cache is still at capacity
+	cache.mu.Lock()
+	assert.Equal(t, cacheSize, len(cache.cache), "Cache should still be at capacity")
+	assert.Equal(t, cacheSize, cache.lruList.Len(), "LRU list should still match cache size")
+
+	// Verify label-1 was evicted (oldest)
+	_, exists := cache.cache["label-1"]
+	assert.False(t, exists, "Oldest entry (label-1) should have been evicted")
+
+	// Verify label-3 is still in cache (was accessed recently)
+	_, exists = cache.cache["label-3"]
+	assert.True(t, exists, "Recently accessed entry (label-3) should still be in cache")
+
+	// Verify label-6 is in cache (just added)
+	_, exists = cache.cache["label-6"]
+	assert.True(t, exists, "Newly added entry (label-6) should be in cache")
+	cache.mu.Unlock()
+}
+
+// TestLabelFilterCache_LRUOrdering tests that cache maintains proper LRU ordering
+func TestLabelFilterCache_LRUOrdering(t *testing.T) {
+	patterns := []string{"^app$", "^tier$", "^env$"}
+	cacheSize := 3
+
+	podMapper := &PodMapper{
+		Config: &appconfig.Config{
+			KubernetesPodLabelAllowlistRegex: patterns,
+		},
+		labelFilterCache: newLabelFilterCache(patterns, cacheSize),
+	}
+
+	cache := podMapper.labelFilterCache
+
+	// Add entries in order: app, tier, env
+	podMapper.shouldIncludeLabel("app")
+	podMapper.shouldIncludeLabel("tier")
+	podMapper.shouldIncludeLabel("env")
+
+	// Cache should be at capacity with order (front to back): env, tier, app
+	cache.mu.Lock()
+	assert.Equal(t, cacheSize, len(cache.cache), "Cache should be at capacity")
+
+	// Verify front is most recent (env)
+	front := cache.lruList.Front()
+	assert.Equal(t, "env", front.Value.(*labelCacheEntry).key, "Front should be most recent (env)")
+
+	// Verify back is oldest (app)
+	back := cache.lruList.Back()
+	assert.Equal(t, "app", back.Value.(*labelCacheEntry).key, "Back should be oldest (app)")
+	cache.mu.Unlock()
+
+	// Access "app" to move it to front
+	podMapper.shouldIncludeLabel("app")
+
+	// Now order should be (front to back): app, env, tier
+	cache.mu.Lock()
+	front = cache.lruList.Front()
+	assert.Equal(t, "app", front.Value.(*labelCacheEntry).key, "Front should now be app")
+
+	back = cache.lruList.Back()
+	assert.Equal(t, "tier", back.Value.(*labelCacheEntry).key, "Back should now be tier")
+	cache.mu.Unlock()
+
+	// Add new entry "version" - should evict "tier" (now oldest)
+	podMapper.shouldIncludeLabel("version")
+
+	cache.mu.Lock()
+	_, tierExists := cache.cache["tier"]
+	assert.False(t, tierExists, "tier should have been evicted")
+
+	_, versionExists := cache.cache["version"]
+	assert.True(t, versionExists, "version should be in cache")
+
+	_, appExists := cache.cache["app"]
+	assert.True(t, appExists, "app should still be in cache")
+
+	_, envExists := cache.cache["env"]
+	assert.True(t, envExists, "env should still be in cache")
+	cache.mu.Unlock()
+}
+
+// TestLabelFilterCache_ConcurrentAccess tests that the cache is safe for concurrent use
+func TestLabelFilterCache_ConcurrentAccess(t *testing.T) {
+	patterns := []string{"^label-.*"}
+	cacheSize := 100
+
+	podMapper := &PodMapper{
+		Config: &appconfig.Config{
+			KubernetesPodLabelAllowlistRegex: patterns,
+		},
+		labelFilterCache: newLabelFilterCache(patterns, cacheSize),
+	}
+
+	// Launch multiple goroutines to access cache concurrently
+	const numGoroutines = 10
+	const numOperationsPerGoroutine = 100
+
+	done := make(chan bool)
+
+	for g := 0; g < numGoroutines; g++ {
+		go func(goroutineID int) {
+			for i := 0; i < numOperationsPerGoroutine; i++ {
+				labelKey := fmt.Sprintf("label-%d-%d", goroutineID, i)
+				podMapper.shouldIncludeLabel(labelKey)
+			}
+			done <- true
+		}(g)
+	}
+
+	// Wait for all goroutines to complete
+	for g := 0; g < numGoroutines; g++ {
+		<-done
+	}
+
+	// Verify cache is within size limits
+	cache := podMapper.labelFilterCache
+	cache.mu.Lock()
+	assert.LessOrEqual(t, len(cache.cache), cacheSize, "Cache should not exceed max size")
+	assert.LessOrEqual(t, cache.lruList.Len(), cacheSize, "LRU list should not exceed max size")
+	assert.Equal(t, len(cache.cache), cache.lruList.Len(), "Cache map and list should be in sync")
+	cache.mu.Unlock()
+}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -73,6 +73,7 @@ const (
 	CLIKubernetesEnablePodUID           = "kubernetes-enable-pod-uid"
 	CLIKubernetesGPUIDType              = "kubernetes-gpu-id-type"
 	CLIKubernetesPodLabelAllowlistRegex = "kubernetes-pod-label-allowlist-regex"
+	CLIKubernetesPodLabelCacheSize      = "kubernetes-pod-label-cache-size"
 	CLIUseOldNamespace                  = "use-old-namespace"
 	CLIRemoteHEInfo                     = "remote-hostengine-info"
 	CLIGPUDevices                       = "devices"
@@ -197,6 +198,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   cli.NewStringSlice(),
 			Usage:   "Regex patterns for filtering pod labels to include in metrics (comma-separated). Empty means include all labels. This parameter is effective only when '--kubernetes-enable-pod-labels' is true.",
 			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_POD_LABEL_ALLOWLIST_REGEX"},
+		},
+		&cli.IntFlag{
+			Name:    CLIKubernetesPodLabelCacheSize,
+			Value:   150000,
+			Usage:   "Maximum number of label keys to cache for allowlist filtering. Larger values use more memory but reduce regex evaluations.",
+			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_POD_LABEL_CACHE_SIZE"},
 		},
 		&cli.StringFlag{
 			Name:    CLIGPUDevices,
@@ -709,6 +716,7 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		KubernetesEnablePodUID:           c.Bool(CLIKubernetesEnablePodUID),
 		KubernetesGPUIdType:              appconfig.KubernetesGPUIDType(c.String(CLIKubernetesGPUIDType)),
 		KubernetesPodLabelAllowlistRegex: c.StringSlice(CLIKubernetesPodLabelAllowlistRegex),
+		KubernetesPodLabelCacheSize:      c.Int(CLIKubernetesPodLabelCacheSize),
 		CollectDCP:                       true,
 		UseOldNamespace:                  c.Bool(CLIUseOldNamespace),
 		UseRemoteHE:                      c.IsSet(CLIRemoteHEInfo),


### PR DESCRIPTION
## Fix unbounded memory growth in pod label allowlist cache

### Problem
The pod label allowlist cache used an unbounded `sync.Map` that would grow indefinitely in clusters with high pod churn or diverse label patterns. Over days/weeks, this could consume hundreds of MBs or GBs of memory.

### Solution
Replaced with a bounded LRU cache (using `container/list` + map) that:
- Evicts least recently used entries when full
- Maintains O(1) lookups and updates
- Thread-safe with mutex protection

### Configuration
Added `--kubernetes-pod-label-cache-size` flag (env: `DCGM_EXPORTER_KUBERNETES_POD_LABEL_CACHE_SIZE`)
- Default: 150,000 entries (~18MB)
- Adjustable based on cluster size and memory constraints

### Testing
- Updated existing label filter tests
- Added comprehensive LRU-specific tests covering:
  - Eviction behavior
  - LRU ordering correctness
  - Concurrent access safety