### PR TITLE
feat: updating readme to include OpenObserve blog and dashboards for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ You will also find the `json` file on this repo under `grafana/dcgm-exporter-das
 
 ### You can find the DCGM-Exporter OpenObserve dashboard here
 
-You can find the official NVIDIA DCGM-Exporter dashboard here: <https://github.com/openobserve/dashboards/tree/main/NVIDIA%20GPU%20Monitoring>
+You can find the NVIDIA DCGM-Exporter dashboard here: <https://github.com/openobserve/dashboards/tree/main/NVIDIA%20GPU%20Monitoring>
 
 To integrate DCGM-Exporter with OpenObserve, follow the blog [monitoring GPU with OpenObserve](https://openobserve.ai/blog/how-to-monitor-nvidia-gpu/)
 


### PR DESCRIPTION
- Adding OpenObserve that can monitor GPUs with better dashboards and in-built alerting capabilities.
![gpu-dash](https://github.com/user-attachments/assets/2e36e262-4816-400d-bb9a-2860bf710e82)
![nvidia gpu monitoring](https://github.com/user-attachments/assets/8f1404ba-db48-46c4-993b-2540aa11aab3)
