### PR TITLE
FIX: fix for vailation time us->ns

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -40,12 +40,12 @@ data:
 
       # Errors and violations
       DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
-      # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-      # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-      # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-      # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-      # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-      # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+      # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in ns).
+      # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in ns).
+      # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in ns).
+      # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in ns).
+      # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in ns).
+      # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in ns).
 
       # Memory usage
       DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -287,12 +287,12 @@ kubernetesDRA:
   
   # Errors and violations
   # DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
-  # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-  # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-  # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-  # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-  # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-  # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+  # DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in ns).
+  # DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in ns).
+  # DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in ns).
+  # DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in ns).
+  # DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in ns).
+  # DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in ns).
   
   # Memory usage
   # DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).

--- a/etc/1.x-compatibility-metrics.csv
+++ b/etc/1.x-compatibility-metrics.csv
@@ -27,12 +27,12 @@ dcgm_dec_utilization,      gauge, Decoder utilization (in %).
 
 # Errors and violations
 dcgm_xid_errors,            gauge, Value of the last XID error encountered.
-# dcgm_power_violation,       counter, Throttling duration due to power constraints (in us).
-# dcgm_thermal_violation,     counter, Throttling duration due to thermal constraints (in us).
-# dcgm_sync_boost_violation,  counter, Throttling duration due to sync-boost constraints (in us).
-# dcgm_board_limit_violation, counter, Throttling duration due to board limit constraints (in us).
-# dcgm_low_util_violation,    counter, Throttling duration due to low utilization (in us).
-# dcgm_reliability_violation, counter, Throttling duration due to reliability constraints (in us).
+# dcgm_power_violation,       counter, Throttling duration due to power constraints (in ns).
+# dcgm_thermal_violation,     counter, Throttling duration due to thermal constraints (in ns).
+# dcgm_sync_boost_violation,  counter, Throttling duration due to sync-boost constraints (in ns).
+# dcgm_board_limit_violation, counter, Throttling duration due to board limit constraints (in ns).
+# dcgm_low_util_violation,    counter, Throttling duration due to low utilization (in ns).
+# dcgm_reliability_violation, counter, Throttling duration due to reliability constraints (in ns).
 
 # Memory usage
 dcgm_fb_free, gauge, Framebuffer memory free (in MiB).

--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -27,12 +27,12 @@ DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 
 # Errors and violations
 DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
-# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in ns).
+# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in ns).
+# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in ns).
+# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in ns).
+# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in ns).
+# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in ns).
 
 # Memory usage
 DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -27,12 +27,12 @@ DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 
 # Errors and violations
 DCGM_FI_DEV_XID_ERRORS,              gauge,   Value of the last XID error encountered.
-# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in ns).
+# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in ns).
+# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in ns).
+# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in ns).
+# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in ns).
+# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in ns).
 
 # DCGM Exporter fields
 

--- a/tests/integration/testdata/default-counters.csv
+++ b/tests/integration/testdata/default-counters.csv
@@ -28,12 +28,12 @@ DCGM_FI_DEV_DEC_UTIL ,     gauge, Decoder utilization (in %).
 
 # Errors and violations
 DCGM_FI_DEV_XID_ERRORS,              gauge,   Value of the last XID error encountered.
-# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
-# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
-# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
-# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
-# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
-# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
+# DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in ns).
+# DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in ns).
+# DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in ns).
+# DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in ns).
+# DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in ns).
+# DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in ns).
 # DCGM_EXP_XID_ERRORS_COUNT,         gauge,   Count of XID Errors within user-specified time window (see xid-count-window-size param).
 # Memory usage
 DCGM_FI_DEV_FB_FREE, gauge, Frame buffer memory free (in MB).


### PR DESCRIPTION
FIX: fix for vailation time us->ns
in dcgm  dcgmlib/dcgm_fields.h define the VIOLATION are ns
but in dcgm testing/python3/dcgm_filed.py the VIOLATION filed comment all change to us.

This will also cause errors in the configuration comments in dcgm-exporter. I have checked the official documentation and tested the actual values, confirming that these values ​​should all be in nanoseconds (ns).

