### PR TITLE
Fix Health Endpoint Behavior

### DIFF
--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -268,11 +268,11 @@ func (s *MetricsServer) render(w io.Writer, metricGroups registry.MetricsByCount
 
 func (s *MetricsServer) Health(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	_, err := w.Write([]byte("KO"))
-	if err != nil {
-		slog.Error("Failed to write response.", slog.String(logging.ErrorKey, err.Error()))
-		http.Error(w, "failed to write response", http.StatusInternalServerError)
-	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if _, err := w.Write([]byte("OK")); err != nil {
+		slog.Error("Failed to write health response.", slog.String(logging.ErrorKey, err.Error()))
+		return
+	)
 }
 
 // DumpMetricsToJSON is a helper function for debugging that dumps all metrics to JSON

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -272,7 +272,7 @@ func (s *MetricsServer) Health(w http.ResponseWriter, _ *http.Request) {
 	if _, err := w.Write([]byte("OK")); err != nil {
 		slog.Error("Failed to write health response.", slog.String(logging.ErrorKey, err.Error()))
 		return
-	)
+	}
 }
 
 // DumpMetricsToJSON is a helper function for debugging that dumps all metrics to JSON

--- a/internal/pkg/server/server_test.go
+++ b/internal/pkg/server/server_test.go
@@ -272,9 +272,10 @@ func TestHealthReturnsOK(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Code)
 }
 
-func TestHealthReturnsOKWhenWriteReturnsError(t *testing.T) {
+func TestHealthDoesNotPanicWhenWriteError(t *testing.T) {
 	metricServer := &MetricsServer{}
 	recorder := &mockResponseWriter{}
-	metricServer.Health(recorder, nil)
-	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.NotPanics(t, func() {
+		metricServer.Health(recorder, nil)
+	})
 }


### PR DESCRIPTION
This PR fixing the `/health` endpoint to follow correct HTTP semantics and safer error-handling practices.

fixes https://github.com/NVIDIA/dcgm-exporter/issues/595

Fix the Health endpoint handler with properly
Replaced the status-code assertion test with a `does not panic` test