### PR TITLE
feat: ensure metrics are consistent for docker image and helm chart

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -50,6 +50,7 @@ data:
       # Memory usage
       DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
       DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+      DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
 
       # ECC
       # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
@@ -77,6 +78,9 @@ data:
       DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
       DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
       DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed
+
+      # Static configuration information. These appear as labels on the other metrics
+      DCGM_FI_DRIVER_VERSION,        label, Driver Version
 
       # DCP metrics
       DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active.

--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -91,6 +91,6 @@ data:
       # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active.
       # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active.
       # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
-      DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
-      DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+      DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+      DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
 {{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -297,6 +297,7 @@ kubernetesDRA:
   # Memory usage
   # DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
   # DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+  # DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
   
   # ECC
   # DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
@@ -336,6 +337,9 @@ kubernetesDRA:
   # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
   # DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
   # DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+
+  # Static configuration information
+  # DCGM_FI_DRIVER_VERSION,        label, Driver Version
 
 livenessProbe:
   initialDelaySeconds: 45

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -335,8 +335,8 @@ kubernetesDRA:
   # DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active.
   # DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active.
   # DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active.
-  # DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
-  # DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
+  # DCGM_FI_PROF_PCIE_TX_BYTES,      gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+  # DCGM_FI_PROF_PCIE_RX_BYTES,      gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
 
   # Static configuration information
   # DCGM_FI_DRIVER_VERSION,        label, Driver Version

--- a/internal/pkg/transformation/kubernetes_mig_test.go
+++ b/internal/pkg/transformation/kubernetes_mig_test.go
@@ -372,6 +372,298 @@ const sampleMetricsJSON = `{
         "labels": {},
         "attributes": {}
       }
+    ],
+    "DCGM_FI_DEV_FB_RESERVED": [
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "0",
+        "gpu_uuid": "GPU-be839661-c0f5-7452-284b-b875666df60c",
+        "gpu_device": "nvidia0",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:1B:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "1",
+        "gpu_uuid": "GPU-21c6d9d7-46cd-7e91-99c3-7b6a06a3faea",
+        "gpu_device": "nvidia1",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:43:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "2",
+        "gpu_uuid": "GPU-5d9cc71f-b438-dc00-707d-c6c12bcfede1",
+        "gpu_device": "nvidia2",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:52:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "3",
+        "gpu_uuid": "GPU-81d888ca-dd11-328c-45fa-d6807a1afa6a",
+        "gpu_device": "nvidia3",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:61:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "4",
+        "gpu_uuid": "GPU-c4c7f4f8-af86-6966-c0b2-7c1e40c18347",
+        "gpu_device": "nvidia4",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:9D:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "5",
+        "gpu_uuid": "GPU-7845680c-0e07-1670-c2bb-9f018cd7864b",
+        "gpu_device": "nvidia5",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:C3:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "6",
+        "gpu_uuid": "GPU-f70b214f-9fe8-5a4e-0499-0ff9572959ff",
+        "gpu_device": "nvidia6",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:D1:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 253,
+          "field_name": "DCGM_FI_DEV_FB_RESERVED",
+          "prom_type": "gauge",
+          "help": "Framebuffer memory reserved (in MiB)."
+        },
+        "value": "576",
+        "gpu": "7",
+        "gpu_uuid": "GPU-eb5c9999-ebc3-9a6e-58cc-494befb69b8a",
+        "gpu_device": "nvidia7",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:DF:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      }
+    ],
+    "DCGM_FI_DRIVER_VERSION": [
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "0",
+        "gpu_uuid": "GPU-be839661-c0f5-7452-284b-b875666df60c",
+        "gpu_device": "nvidia0",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:1B:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "1",
+        "gpu_uuid": "GPU-21c6d9d7-46cd-7e91-99c3-7b6a06a3faea",
+        "gpu_device": "nvidia1",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:43:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "2",
+        "gpu_uuid": "GPU-5d9cc71f-b438-dc00-707d-c6c12bcfede1",
+        "gpu_device": "nvidia2",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:52:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "3",
+        "gpu_uuid": "GPU-81d888ca-dd11-328c-45fa-d6807a1afa6a",
+        "gpu_device": "nvidia3",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:61:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "4",
+        "gpu_uuid": "GPU-c4c7f4f8-af86-6966-c0b2-7c1e40c18347",
+        "gpu_device": "nvidia4",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:9D:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "5",
+        "gpu_uuid": "GPU-7845680c-0e07-1670-c2bb-9f018cd7864b",
+        "gpu_device": "nvidia5",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:C3:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "6",
+        "gpu_uuid": "GPU-f70b214f-9fe8-5a4e-0499-0ff9572959ff",
+        "gpu_device": "nvidia6",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:D1:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      },
+      {
+        "counter": {
+          "field_id": 254,
+          "field_name": "DCGM_FI_DRIVER_VERSION",
+          "prom_type": "label",
+          "help": "Driver Version"
+        },
+        "value": "575.51.03",
+        "gpu": "7",
+        "gpu_uuid": "GPU-eb5c9999-ebc3-9a6e-58cc-494befb69b8a",
+        "gpu_device": "nvidia7",
+        "gpu_model": "NVIDIA H100 80GB HBM3",
+        "pci_bus_id": "00000000:DF:00.0",
+        "uuid": "UUID",
+        "hostname": "localhost",
+        "labels": {},
+        "attributes": {}
+      }
     ]
   }
 }`


### PR DESCRIPTION
This PR adds the following default metrics in config map deployed using helm chart.

-  DCGM_FI_DEV_FB_RESERVED
-  DCGM_FI_DRIVER_VERSION 

These metrics were present in docker image build.

Additionally, metric type of following metrics is changed from counter to gauge in config map.
- DCGM_FI_PROF_PCIE_TX_BYTES
- DCGM_FI_PROF_PCIE_TX_BYTES



Resolves #614 