### PR TITLE
helm: increase default memory limit to 512Mi

### DIFF
--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -113,7 +113,7 @@ service:
 resources:
   limits:
     cpu: 200m
-    memory: 256Mi
+    memory: 512Mi
   requests:
     cpu: 100m
     memory: 128Mi


### PR DESCRIPTION
Resolves #609 