### PR TITLE
Fix P2P status mapping to match NVML nvmlGpuP2PStatus_enum

### DIFF
--- a/internal/pkg/collector/const.go
+++ b/internal/pkg/collector/const.go
@@ -24,6 +24,7 @@ const (
 
 	LinkStatusOK                   = "OK"
 	LinkStatusChipsetNotSupported  = "ChipsetNotSupported"
+	LinkStatusGPUNotSupported      = "GPUNotSupported"
 	LinkStatusTopologyNotSupported = "TopologyNotSupported"
 	LinkStatusDisabledByRegKey     = "DisabledByRegKey"
 	LinkStatusNotSupported         = "NotSupported"

--- a/internal/pkg/collector/p2p_status_collector.go
+++ b/internal/pkg/collector/p2p_status_collector.go
@@ -98,11 +98,15 @@ func p2pStatusToString(status uint64) string {
 	case 1:
 		return LinkStatusChipsetNotSupported
 	case 2:
-		return LinkStatusTopologyNotSupported
+		return LinkStatusGPUNotSupported
 	case 3:
-		return LinkStatusDisabledByRegKey
+		return LinkStatusTopologyNotSupported
 	case 4:
+		return LinkStatusDisabledByRegKey
+	case 5:
 		return LinkStatusNotSupported
+	case 6:
+		return LinkStatusUnknown
 	default:
 		return LinkStatusUnknown
 	}

--- a/internal/pkg/collector/p2p_status_collector_test.go
+++ b/internal/pkg/collector/p2p_status_collector_test.go
@@ -78,9 +78,11 @@ func TestP2PStatusToString(t *testing.T) {
 	}{
 		{LinkStatusOK, 0, LinkStatusOK},
 		{LinkStatusChipsetNotSupported, 1, LinkStatusChipsetNotSupported},
-		{LinkStatusTopologyNotSupported, 2, LinkStatusTopologyNotSupported},
-		{LinkStatusDisabledByRegKey, 3, LinkStatusDisabledByRegKey},
-		{LinkStatusNotSupported, 4, LinkStatusNotSupported},
+		{LinkStatusGPUNotSupported, 2, LinkStatusGPUNotSupported},
+		{LinkStatusTopologyNotSupported, 3, LinkStatusTopologyNotSupported},
+		{LinkStatusDisabledByRegKey, 4, LinkStatusDisabledByRegKey},
+		{LinkStatusNotSupported, 5, LinkStatusNotSupported},
+		{LinkStatusUnknown, 6, LinkStatusUnknown},
 		{LinkStatusUnknown, 99, LinkStatusUnknown},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Fixed incorrect P2P status mapping in `p2pStatusToString` that was missing `NVML_P2P_STATUS_GPU_NOT_SUPPORTED` (value 2), causing all subsequent status values to be shifted by one
- Status value 5 (`NotSupported`) was incorrectly reported as `Unknown`, and values 2-4 were mapped to wrong status strings

## Problem
The `p2pStatusToString` function in `p2p_status_collector.go` did not include `GPU_NOT_SUPPORTED` (value 2) from the NVML `nvmlGpuP2PStatus_enum`, causing a mapping mismatch:

| Value | NVML enum (`nvml.h`) | Before (incorrect) | After (correct) |
|-------|------|------|------|
| 0 | OK | OK ✓ | OK ✓ |
| 1 | ChipsetNotSupported | ChipsetNotSupported ✓ | ChipsetNotSupported ✓ |
| 2 | **GPUNotSupported** | TopologyNotSupported ✗ | **GPUNotSupported** ✓ |
| 3 | TopologyNotSupported | DisabledByRegKey ✗ | TopologyNotSupported ✓ |
| 4 | DisabledByRegKey | NotSupported ✗ | DisabledByRegKey ✓ |
| 5 | NotSupported | Unknown ✗ | NotSupported ✓ |
| 6 | Unknown | Unknown ✓ | Unknown ✓ |

## Reference
[`nvmlGpuP2PStatus_enum` in nvml.h](https://github.com/NVIDIA/go-dcgm/blob/6cbb0463ce9fe6edde7bf409c87166d2d8f35d40/pkg/dcgm/nvml.h#L513-L525)

## Changes
- `const.go`: Added `LinkStatusGPUNotSupported` constant
- `p2p_status_collector.go`: Fixed `p2pStatusToString` mapping to align with `nvmlGpuP2PStatus_enum`
- `p2p_status_collector_test.go`: Updated test cases to match corrected mapping

## Test plan
- [x] Updated unit tests for `p2pStatusToString` with all 7 enum values
- [ ] Verify P2P status labels are correctly reported in Prometheus metrics on a multi-GPU node