### PR TITLE
fix(grafana-dashboard): change to new DCGM_FI_PROF_GR_ENGINE_ACTIVE

### DIFF
--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -494,7 +494,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\", gpu=~\"$gpu\"}",
+          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
           "legendFormat": "GPU {{gpu}}",
           "refId": "A"
@@ -520,10 +520,10 @@
       },
       "yaxes": [
         {
-          "format": "percent",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": "100",
+          "max": "1",
           "min": "0",
           "show": true
         },


### PR DESCRIPTION
I am using GPU Operator v25.10.1,  the GPU Utilization panel in Grafana does not work.


If I am correct,

- `DCGM_FI_DEV_GPU_UTIL` is legacy from old dcgm-exporter
- `DCGM_FI_PROF_GR_ENGINE_ACTIVE` is profiling-based and from current dcgm-exporter

After this fix, I can confirm it works again. ☺️

<img width="3196" height="2029" alt="image" src="https://github.com/user-attachments/assets/519ffe5a-8f35-4a9a-82c5-9b3c987aac89" />

