### PR TITLE
Remove vulnerable helper binaries from distroless image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -339,6 +339,12 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,compat32
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
 
+# Remove unused helper binaries from the base image that are built with an
+# older Go toolchain and carry known CVEs (e.g. CVE-2025-68121).
+# dcgm-exporter does not reference these binaries.
+COPY --from=runtime-distroless-helper --chown=root:root --chmod=755 /bin/rm /bin/rm
+RUN rm -f /usr/bin/shelless_ulimit_* /usr/bin/sleep_* /bin/rm
+
 # Security Note: Default USER
 #
 # This container runs as root by default because:


### PR DESCRIPTION
## Summary

- Remove `shelless_ulimit_*` and `sleep_*` helper binaries from the distroless image that carry 1 CRITICAL + 3 HIGH CVEs due to being built with Go 1.25.5
- These binaries come from the NVIDIA distroless base image (`nvcr.io/nvidia/distroless/cc:v4.0.1`) and are not referenced by dcgm-exporter

## Problem

Trivy scan of the current distroless image shows 4 fixable vulnerabilities in two helper binaries shipped by the base image:

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2025-68121 | CRITICAL | crypto/tls: Unexpected session resumption |
| CVE-2025-61726 | HIGH | net/url: Memory exhaustion in query parameter parsing |
| CVE-2025-61728 | HIGH | archive/zip: Excessive CPU consumption |
| CVE-2025-61730 | HIGH | TLS 1.3 handshake issue |

All are fixed in Go >= 1.25.7, but the base image binaries were built with Go 1.25.5.

## Fix

Since dcgm-exporter does not use `shelless_ulimit_*` or `sleep_*` (confirmed via codebase grep), this PR removes them from the final distroless image by temporarily copying `rm` from the helper stage and deleting them.

## Scan Results (Before → After)

| Severity | Before | After |
|----------|--------|-------|
| CRITICAL | 1 | **0** |
| HIGH | 4 | **1** (glibc CVE-2026-0861 — no upstream fix available) |

## Test Plan

- [x] Built distroless image locally with the change
- [x] Trivy scan confirms CRITICAL drops to 0 and HIGH drops from 4 to 1
- [x] Remaining HIGH (glibc CVE-2026-0861) has no fix available in Debian
- [ ] Verify dcgm-exporter starts and serves metrics correctly with the modified image