### PR TITLE
Show hostname in GPU legends for Grafana dashboard (#630); add doc

### DIFF
--- a/grafana/HOSTNAME_LEGEND_UPDATE.md
+++ b/grafana/HOSTNAME_LEGEND_UPDATE.md
@@ -1,0 +1,13 @@
+# Dashboard Update: Hostname in GPU Legends
+
+The Grafana dashboard now displays the hostname in all GPU graph legends (e.g., "GPU 0 on myhost").
+
+**How it works:**
+- The `legendFormat` for each GPU panel now includes `{{hostname}}`.
+- This helps distinguish metrics from GPUs with the same number on different hosts.
+
+**No changes are needed to your Prometheus queries or exporters if you already have the `hostname` label in your metrics.**
+
+---
+
+_This change addresses: https://github.com/NVIDIA/dcgm-exporter/issues/630_

--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -245,7 +245,7 @@
         {
           "expr": "DCGM_FI_DEV_POWER_USAGE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "GPU {{gpu}} on {{hostname}}",
           "refId": "A"
         }
       ],
@@ -405,7 +405,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "GPU {{gpu}} on {{hostname}}",
           "refId": "A"
         }
       ],
@@ -496,7 +496,7 @@
         {
           "expr": "DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "GPU {{gpu}} on {{hostname}}",
           "refId": "A"
         }
       ],
@@ -586,7 +586,7 @@
         {
           "expr": "DCGM_FI_DEV_FB_USED{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "GPU {{gpu}} on {{hostname}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Show hostname in GPU legends for Grafana dashboard (#630)

This PR updates the Grafana dashboard so that all GPU graph legends now include the hostname (e.g., “GPU 0 on myhost”). This makes it much easier to distinguish between GPUs with the same number on different hosts, especially in multi-node environments.

Updated all relevant legendFormat fields in [dcgm-exporter-dashboard.json](vscode-file://vscode-app/private/var/folders/kp/77zwg3h95gj0t60rk_1_ss840000gn/T/AppTranslocation/055B4A69-C8BF-45C4-9427-284ED80E7844/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to include {{hostname}}.
Added a short documentation note in [HOSTNAME_LEGEND_UPDATE.md](vscode-file://vscode-app/private/var/folders/kp/77zwg3h95gj0t60rk_1_ss840000gn/T/AppTranslocation/055B4A69-C8BF-45C4-9427-284ED80E7844/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
This change addresses [issue #630](vscode-file://vscode-app/private/var/folders/kp/77zwg3h95gj0t60rk_1_ss840000gn/T/AppTranslocation/055B4A69-C8BF-45C4-9427-284ED80E7844/d/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).

