### PR TITLE
Add vsock support for serving metrics to hypervisors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 	github.com/NVIDIA/go-nvml v0.12.4-1
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/bits-and-blooms/bitset v1.22.0
+	github.com/containerd/cgroups/v3 v3.1.1
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
+	github.com/mdlayher/vsock v1.2.1
 	github.com/mittwald/go-helm-client v0.12.16
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.0
@@ -49,7 +51,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
-	github.com/containerd/cgroups/v3 v3.1.1 // indirect
 	github.com/containerd/containerd v1.7.27 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
@@ -99,7 +100,6 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/mdlayher/socket v0.5.1 // indirect
-	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,7 +44,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnTiM80=
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups/v3 v3.1.1 h1:ASZmQGfOHbRj43/1aMn5QcWIsv0R/AuHHDNCguRY0p0=
 github.com/containerd/cgroups/v3 v3.1.1/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd v1.7.27 h1:yFyEyojddO3MIGVER2xJLWoCIn+Up4GaHFquP7hsFII=

--- a/internal/mocks/pkg/nvmlprovider/mock_client.go
+++ b/internal/mocks/pkg/nvmlprovider/mock_client.go
@@ -66,21 +66,6 @@ func (mr *MockNVMLMockRecorder) Cleanup() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Cleanup", reflect.TypeOf((*MockNVML)(nil).Cleanup))
 }
 
-// GetDeviceProcessMemory mocks base method.
-func (m *MockNVML) GetDeviceProcessMemory(gpuUUID string) (map[uint32]uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDeviceProcessMemory", gpuUUID)
-	ret0, _ := ret[0].(map[uint32]uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDeviceProcessMemory indicates an expected call of GetDeviceProcessMemory.
-func (mr *MockNVMLMockRecorder) GetDeviceProcessMemory(gpuUUID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceProcessMemory", reflect.TypeOf((*MockNVML)(nil).GetDeviceProcessMemory), gpuUUID)
-}
-
 // GetAllMIGDevicesProcessMemory mocks base method.
 func (m *MockNVML) GetAllMIGDevicesProcessMemory(parentGPUUUID string) (map[uint]map[uint32]uint64, error) {
 	m.ctrl.T.Helper()
@@ -94,6 +79,21 @@ func (m *MockNVML) GetAllMIGDevicesProcessMemory(parentGPUUUID string) (map[uint
 func (mr *MockNVMLMockRecorder) GetAllMIGDevicesProcessMemory(parentGPUUUID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllMIGDevicesProcessMemory", reflect.TypeOf((*MockNVML)(nil).GetAllMIGDevicesProcessMemory), parentGPUUUID)
+}
+
+// GetDeviceProcessMemory mocks base method.
+func (m *MockNVML) GetDeviceProcessMemory(gpuUUID string) (map[uint32]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeviceProcessMemory", gpuUUID)
+	ret0, _ := ret[0].(map[uint32]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeviceProcessMemory indicates an expected call of GetDeviceProcessMemory.
+func (mr *MockNVMLMockRecorder) GetDeviceProcessMemory(gpuUUID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceProcessMemory", reflect.TypeOf((*MockNVML)(nil).GetDeviceProcessMemory), gpuUUID)
 }
 
 // GetDeviceProcessUtilization mocks base method.

--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -76,4 +76,5 @@ type Config struct {
 	DisableStartupValidate           bool
 	EnableGPUBindUnbindWatch         bool          // Enable GPU bind/unbind event monitoring
 	GPUBindUnbindPollInterval        time.Duration // Poll interval for GPU bind/unbind events
+	VSOCKPort                        uint32        // VSOCK port to listen on (0 = disabled)
 }

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/mdlayher/vsock"
 	"github.com/prometheus/exporter-toolkit/web"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
@@ -201,6 +202,31 @@ func (s *MetricsServer) Run(ctx context.Context, stop chan interface{}) {
 		}
 	}()
 
+	if s.config.VSOCKPort > 0 {
+		httpwg.Add(1)
+		go func() {
+			defer httpwg.Done()
+			l, err := vsock.Listen(s.config.VSOCKPort, nil)
+			if err != nil {
+				slog.Error("Failed to listen on vsock.",
+					slog.Uint64("port", uint64(s.config.VSOCKPort)),
+					slog.String(logging.ErrorKey, err.Error()))
+				return
+			}
+			defer l.Close()
+			slog.Info("Listening on vsock.", slog.Uint64("port", uint64(s.config.VSOCKPort)))
+
+			s.vsockServer = &http.Server{
+				Handler:      s.server.Handler,
+				ReadTimeout:  10 * time.Second,
+				WriteTimeout: 10 * time.Second,
+			}
+			if err := s.vsockServer.Serve(l); err != nil && err != http.ErrServerClosed {
+				slog.Error("VSOCK server error.", slog.String(logging.ErrorKey, err.Error()))
+			}
+		}()
+	}
+
 	httpwg.Add(1)
 	go func() {
 		defer httpwg.Done()
@@ -227,6 +253,11 @@ func (s *MetricsServer) Run(ctx context.Context, stop chan interface{}) {
 	<-stop
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 	defer shutdownCancel()
+	if s.vsockServer != nil {
+		if err := s.vsockServer.Shutdown(shutdownCtx); err != nil {
+			slog.Error("Failed to shutdown VSOCK server.", slog.String(logging.ErrorKey, err.Error()))
+		}
+	}
 	if err := s.server.Shutdown(shutdownCtx); err != nil {
 		slog.Error("Failed to shutdown HTTP server.", slog.String(logging.ErrorKey, err.Error()))
 		s.fatal()

--- a/internal/pkg/server/server_test.go
+++ b/internal/pkg/server/server_test.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"net"
 	"net/http"
@@ -24,9 +25,11 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	mockcollectorpkg "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/collector"
@@ -311,4 +314,79 @@ func TestHealthReturnsOKWithRegistryAvailable(t *testing.T) {
 	assert.Equal(t, http.StatusOK, recorder.Code)
 	assert.Equal(t, "true", recorder.Header().Get("X-Registry-Available"))
 	assert.NotEqual(t, "true", recorder.Header().Get("X-Reload-In-Progress"))
+}
+
+func TestVSOCKServerSharesHandler(t *testing.T) {
+	config := &appconfig.Config{
+		Address:   ":0",
+		VSOCKPort: 9400,
+	}
+
+	reg := registry.NewRegistry()
+	server, cleanup, err := NewMetricsServer(config, nil, reg)
+	require.NoError(t, err)
+	defer cleanup()
+
+	// The vsock server is only created during Run(), but verify the config is stored
+	assert.Equal(t, uint32(9400), server.config.VSOCKPort)
+	assert.Nil(t, server.vsockServer)
+}
+
+func TestVSOCKServerDisabledByDefault(t *testing.T) {
+	config := &appconfig.Config{
+		Address:   ":0",
+		VSOCKPort: 0,
+	}
+
+	reg := registry.NewRegistry()
+	server, cleanup, err := NewMetricsServer(config, nil, reg)
+	require.NoError(t, err)
+	defer cleanup()
+
+	assert.Equal(t, uint32(0), server.config.VSOCKPort)
+	assert.Nil(t, server.vsockServer)
+}
+
+func TestVSOCKServerShutdown(t *testing.T) {
+	// Create a TCP listener to simulate the vsock server (vsock.Listen won't work outside a VM)
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	handler := http.NewServeMux()
+	handler.HandleFunc("/metrics", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	vsockSrv := &http.Server{
+		Handler:      handler,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		if err := vsockSrv.Serve(tcpListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("vsockSrv.Serve failed: %v", err)
+		}
+	}()
+
+	// Verify it's serving
+	resp, err := http.Get("http://" + tcpListener.Addr().String() + "/metrics")
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	resp.Body.Close()
+
+	// Simulate the shutdown path
+	metricServer := &MetricsServer{
+		vsockServer: vsockSrv,
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = metricServer.vsockServer.Shutdown(shutdownCtx)
+	assert.NoError(t, err)
+
+	// After shutdown, connections should be refused
+	_, err = http.Get("http://" + tcpListener.Addr().String() + "/metrics")
+	assert.Error(t, err)
 }

--- a/internal/pkg/server/types.go
+++ b/internal/pkg/server/types.go
@@ -34,6 +34,7 @@ type MetricsServer struct {
 	sync.RWMutex
 
 	server                 *http.Server
+	vsockServer            *http.Server
 	webConfig              *web.FlagConfig
 	metrics                string
 	registry               atomic.Pointer[registry.Registry]

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"os/signal"
 	"runtime"
@@ -102,6 +103,7 @@ const (
 	CLIDisableStartupValidate           = "disable-startup-validate"
 	CLIEnableGPUBindUnbindWatch         = "enable-gpu-bind-unbind-watch"
 	CLIGPUBindUnbindPollInterval        = "gpu-bind-unbind-poll-interval"
+	CLIVSOCKPort                        = "vsock-port"
 )
 
 func NewApp(buildVersion ...string) *cli.App {
@@ -348,6 +350,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Usage:   "Interval for polling GPU bind/unbind events (DCGM recommends 1s)",
 			EnvVars: []string{"DCGM_EXPORTER_GPU_BIND_UNBIND_POLL_INTERVAL"},
 			Value:   "1s",
+		},
+		&cli.UintFlag{
+			Name:    CLIVSOCKPort,
+			Value:   0,
+			Usage:   "VSOCK port to listen on for host-guest communication (0 = disabled). Used to expose metrics to a hypervisor via virtio-vsock.",
+			EnvVars: []string{"DCGM_EXPORTER_VSOCK_PORT"},
 		},
 	}
 
@@ -1075,6 +1083,11 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		return nil, fmt.Errorf("invalid %s parameter value: %s", CLIDCGMLogLevel, dcgmLogLevel)
 	}
 
+	if c.Uint(CLIVSOCKPort) > math.MaxUint32 {
+		return nil, fmt.Errorf("vsock port must be in range 1-65535")
+	}
+	vsockPort := uint32(c.Uint(CLIVSOCKPort)) // #nosec G115
+
 	return &appconfig.Config{
 		CollectorsFile:                   c.String(CLIFieldsFile),
 		Address:                          c.String(CLIAddress),
@@ -1116,6 +1129,7 @@ func contextToConfig(c *cli.Context) (*appconfig.Config, error) {
 		DisableStartupValidate:    c.Bool(CLIDisableStartupValidate),
 		EnableGPUBindUnbindWatch:  c.Bool(CLIEnableGPUBindUnbindWatch),
 		GPUBindUnbindPollInterval: parseDuration(c.String(CLIGPUBindUnbindPollInterval), 1*time.Second),
+		VSOCKPort:                 vsockPort,
 	}, nil
 }
 

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -367,3 +367,79 @@ func Test_contextToConfig_DumpConfig(t *testing.T) {
 		})
 	}
 }
+
+func Test_contextToConfig_VSOCKPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		flags        map[string]string
+		expectedPort uint32
+	}{
+		{
+			name: "Default vsock port is 0 (disabled)",
+			flags: map[string]string{
+				CLIGPUDevices: "f",
+			},
+			expectedPort: 0,
+		},
+		{
+			name: "Custom vsock port",
+			flags: map[string]string{
+				CLIGPUDevices: "f",
+				CLIVSOCKPort:  "9400",
+			},
+			expectedPort: 9400,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := cli.NewApp()
+			app.Flags = []cli.Flag{
+				&cli.StringFlag{Name: CLIGPUDevices},
+				&cli.StringFlag{Name: CLISwitchDevices},
+				&cli.StringFlag{Name: CLICPUDevices},
+				&cli.StringFlag{Name: CLIDCGMLogLevel},
+				&cli.UintFlag{Name: CLIVSOCKPort},
+			}
+
+			set := flag.NewFlagSet("test", 0)
+
+			if _, ok := tt.flags[CLIGPUDevices]; !ok {
+				set.String(CLIGPUDevices, "f", "")
+			}
+			if _, ok := tt.flags[CLISwitchDevices]; !ok {
+				set.String(CLISwitchDevices, "f", "")
+			}
+			if _, ok := tt.flags[CLICPUDevices]; !ok {
+				set.String(CLICPUDevices, "f", "")
+			}
+			if _, ok := tt.flags[CLIDCGMLogLevel]; !ok {
+				set.String(CLIDCGMLogLevel, "NONE", "")
+			}
+			if _, ok := tt.flags[CLIVSOCKPort]; !ok {
+				set.Uint(CLIVSOCKPort, 0, "")
+			}
+
+			for name, value := range tt.flags {
+				for _, f := range app.Flags {
+					if f.Names()[0] == name {
+						switch f.(type) {
+						case *cli.StringFlag:
+							set.String(name, value, "")
+						case *cli.UintFlag:
+							if intVal, err := strconv.Atoi(value); err == nil && intVal >= 0 {
+								set.Uint(name, uint(intVal), "")
+							}
+						}
+						break
+					}
+				}
+			}
+
+			context := cli.NewContext(app, set, nil)
+			config, err := contextToConfig(context)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPort, config.VSOCKPort)
+		})
+	}
+}


### PR DESCRIPTION
Add an optional AF_VSOCK listener that serves the same metrics endpoint over virtio-vsock, enabling guest to host metrics collection without network dependencies.

In GPU passthrough and vGPU use cases on KubeVirt (and other hypervisors), the guest VM is often not configured with a network path to the host, but needs GPU telemetry from dcgm-exporter running inside the guest.