### PR TITLE
fix: correct Prometheus type for NVLink bandwidth fields from counter to gauge

### DIFF
--- a/deployment/templates/metrics-configmap.yaml
+++ b/deployment/templates/metrics-configmap.yaml
@@ -67,8 +67,8 @@ data:
       # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
       # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
       # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-      DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
-      # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+      DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            gauge,   NVLink total throughput for all lanes (MiB/s, TX+RX combined).
+      # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               gauge,   NVLink throughput for lane 0 (MiB/s, TX+RX combined).
 
       # VGPU License status
       DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -322,8 +322,8 @@ kubernetesDRA:
   # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
   # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
   # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-  # DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
-  # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+  # DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            gauge,   NVLink total throughput for all lanes (MiB/s, TX+RX combined).
+  # DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               gauge,   NVLink throughput for lane 0 (MiB/s, TX+RX combined).
   
   # VGPU License status
   # DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status

--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -55,8 +55,8 @@ DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
 # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
 # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
-# DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            gauge,   NVLink total throughput for all lanes (MiB/s, TX+RX combined).
+# DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               gauge,   NVLink throughput for lane 0 (MiB/s, TX+RX combined).
 
 # VGPU License status
 DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -62,8 +62,8 @@ DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
 # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
 # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes.
-# DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               counter, The number of bytes of active NVLink rx or tx data including both header and payload.
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            gauge,   NVLink total throughput for all lanes (MiB/s, TX+RX combined).
+# DCGM_FI_DEV_NVLINK_BANDWIDTH_L0,               gauge,   NVLink throughput for lane 0 (MiB/s, TX+RX combined).
 
 # VGPU License status
 DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status

--- a/tests/integration/testdata/default-counters.csv
+++ b/tests/integration/testdata/default-counters.csv
@@ -55,7 +55,7 @@ DCGM_FI_DEV_FB_USED, gauge, Frame buffer memory used (in MB).
 # DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
 # DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
 # DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
-DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            gauge,   NVLink total throughput for all lanes (MiB/s, TX+RX combined)
 
 # VGPU License status
 DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status


### PR DESCRIPTION
## Summary

Fixes the Prometheus metric type for `DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL`
(and its commented-out per-lane variant `DCGM_FI_DEV_NVLINK_BANDWIDTH_L0`)
from `counter` to `gauge`.

Fixes #417

## Root Cause

DCGM field 449 (`DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL`) is an alias for
`DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL`. Internally, DCGM reads the raw
NVML cumulative KiB counters (`NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_RX`
and `NVML_FI_DEV_NVLINK_THROUGHPUT_DATA_TX`, field IDs 138/139, unit
documented as KiB in `nvml.h`) and converts them to an instantaneous
throughput rate in `ReadAndCacheNvLinkBandwidth()`
(`dcgmlib/src/DcgmCacheManager.cpp`):

```cpp
double valueDbl = (double)(currentSum - prevValue->val2.i64);
valueDbl /= timeDiffSec;  // KiB/s
valueDbl /= 1000.0;       // MiB/s (approximate)
```

The published value is therefore an instantaneous MiB/s rate that
fluctuates with NVLink activity. It is a gauge, not a counter.

## Impact

Users whose Grafana dashboards apply rate() or increase() to this
metric (which is the correct treatment for a counter) get near-zero or
meaningless results. The actual NVLink throughput is hidden.

## Changes
- Updated metric type from counter to gauge in all 5 config files
- Updated help text to accurately describe the value as a throughput rate
(MiB/s, TX+RX combined) rather than "number of NVLink bandwidth counters"