### PR TITLE
support pod label collection on MIG

### DIFF
--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -388,6 +388,7 @@ func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo devic
 					if pi.VGPU != "" {
 						metric.Attributes[vgpuAttribute] = pi.VGPU
 					}
+					maps.Copy(metric.Labels, pi.Labels)
 
 					// Robustness: ensure no overlap between Labels and Attributes
 					for k := range metric.Attributes {


### PR DESCRIPTION
## Summary
Builds upon the existing Kubernetes pod label support by ensuring labels resolved for MIG workloads are propagated to the final exported metrics.
Today, pod metadata can already be resolved for MIG-backed workloads, but the labels are not copied into the final metrics emitted from the shared/MIG enrichment path. This causes inconsistent behavior between standard GPU metrics and MIG metrics, and prevents label-based filtering and aggregation for MIG workloads.
## Implementation
Extends the metric enrichment flow for MIG/shared GPU workloads so that the pod labels already collected by `PodMapper` are copied into the final metric labels, matching the behavior of the standard GPU mapping path.
### Key Changes
- Preserve parsed pod labels when emitting metrics for MIG-backed workloads 
- Align MIG/shared GPU metric enrichment with the existing non-MIG pod label behavior

## Configuration
No new flags or configuration are introduced.
Existing Kubernetes pod label settings continue to apply, and this change makes that behavior consistent for MIG metrics as well.
