### PR TITLE
collector: allocate a fresh label map per entity in experimental collectors

### DIFF
--- a/internal/pkg/collector/expcollector.go
+++ b/internal/pkg/collector/expcollector.go
@@ -70,9 +70,6 @@ func (c *expCollector) getMetrics() (MetricsByCounter, error) {
 		}
 	}
 
-	labels := map[string]string{}
-	labels[windowSizeInMSLabel] = fmt.Sprint(c.windowSize)
-
 	monitoringInfo := devicemonitoring.GetMonitoredEntities(c.deviceWatchList.DeviceInfo())
 	metrics := make(MetricsByCounter)
 	useOld := c.config.UseOldNamespace
@@ -81,6 +78,11 @@ func (c *expCollector) getMetrics() (MetricsByCounter, error) {
 		uuid = "uuid"
 	}
 	for _, mi := range monitoringInfo {
+		// Build a fresh label set per entity. getLabelsFromCounters only adds keys, so a map
+		// shared across entities would leak stale label keys to GPUs that lack them, and the
+		// idle-GPU branch below hands the map to createMetric, which stores it by reference.
+		labels := map[string]string{}
+		labels[windowSizeInMSLabel] = fmt.Sprint(c.windowSize)
 		if len(c.labelsCounters) > 0 && len(c.deviceWatchList.LabelDeviceFields()) > 0 {
 			err := c.getLabelsFromCounters(mi, labels)
 			if err != nil {

--- a/internal/pkg/collector/gpu_health_collector.go
+++ b/internal/pkg/collector/gpu_health_collector.go
@@ -164,9 +164,10 @@ func (c *gpuHealthStatusCollector) GetMetrics() (MetricsByCounter, error) {
 	// Each health watch may contribute at most one incident per entity for this scrape.
 	applyGPUHealthIncidents(entityHealthSystemToIncident, gpuHealthStatus.Incidents)
 
-	labels := map[string]string{}
-
 	for _, mi := range monitoringInfoInGroup {
+		// Build a fresh label set per entity. getLabelsFromCounters only adds keys, so a map
+		// shared across entities would leak stale label keys to GPUs that lack them.
+		labels := map[string]string{}
 		if len(c.labelsCounters) > 0 && len(c.deviceWatchList.LabelDeviceFields()) > 0 {
 			err := c.getLabelsFromCounters(mi, labels)
 			if err != nil {

--- a/internal/pkg/collector/p2p_status_collector.go
+++ b/internal/pkg/collector/p2p_status_collector.go
@@ -63,9 +63,10 @@ func (c *p2pStatusCollector) GetMetrics() (MetricsByCounter, error) {
 		uuid = "uuid"
 	}
 
-	labels := map[string]string{}
-
 	for i, status := range p2pStatus.Gpus {
+		// Build a fresh label set per source GPU. getLabelsFromCounters only adds keys, so a
+		// map shared across entities would leak stale label keys to GPUs that lack them.
+		labels := map[string]string{}
 		for j, link := range status {
 			if i == j {
 				continue

--- a/internal/pkg/collector/xid_collector_test.go
+++ b/internal/pkg/collector/xid_collector_test.go
@@ -601,3 +601,83 @@ func Test_xidCollector_GetMetrics(t *testing.T) {
 		})
 	}
 }
+
+// Test_xidCollector_GetMetrics_PerEntityLabelIsolation verifies that per-entity labels do not
+// bleed between GPUs. An idle GPU (no XID events) takes the zero-value branch, which previously
+// shared a single label map across all entities: the map was handed to createMetric by reference
+// and then mutated by the next GPU's getLabelsFromCounters call, so the idle GPU ended up
+// reporting another GPU's label value.
+func Test_xidCollector_GetMetrics_PerEntityLabelIsolation(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDCGM := mockdcgm.NewMockDCGM(ctrl)
+	mockDeviceWatcher := mockdevicewatcher.NewMockWatcher(ctrl)
+
+	realDCGM := dcgmprovider.Client()
+	defer func() { dcgmprovider.SetClient(realDCGM) }()
+	dcgmprovider.SetClient(mockDCGM)
+
+	xidCounter := counters.Counter{FieldID: 1, FieldName: counters.DCGMExpXIDErrorsCount}
+	labelFieldID := dcgm.Short(3)
+	labelName := "label_field"
+	labelCounter := counters.Counter{FieldID: labelFieldID, FieldName: labelName, PromType: "label"}
+
+	gOpts := appconfig.DeviceOptions{Flex: true}
+	mockGPUDeviceInfo := testutils.MockGPUDeviceInfo(ctrl, 2, nil)
+	mockGPUDeviceInfo.EXPECT().GOpts().Return(gOpts).AnyTimes()
+
+	gpuID0 := uint(0)
+	gpuID1 := uint(1)
+
+	mockGroupHandle := dcgm.GroupHandle{}
+	mockGroupHandle.SetHandle(uintptr(1))
+	mockFieldGroupHandle := dcgm.FieldHandle{}
+	mockFieldGroupHandle.SetHandle(uintptr(1))
+
+	// Distinct per-GPU label values so a cross-entity bleed is observable.
+	const gpu0Label = "gpu0-label"
+	const gpu1Label = "gpu1-label"
+	labelValuesFor := func(v string) []dcgm.FieldValue_v1 {
+		return []dcgm.FieldValue_v1{
+			{FieldID: labelFieldID, FieldType: dcgm.DCGM_FT_STRING, Value: testutils.StrToByteArray(v)},
+		}
+	}
+
+	// Only GPU1 has an XID event; GPU0 is idle and takes the zero-value branch.
+	mockEntitiesResult := []dcgm.FieldValue_v2{
+		{EntityID: gpuID1, FieldType: dcgm.DCGM_FT_INT64, Value: [4096]byte{42}},
+	}
+
+	mockDeviceWatcher.EXPECT().WatchDeviceFields(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return([]dcgm.GroupHandle{mockGroupHandle}, mockFieldGroupHandle, []func(){}, nil)
+	mockDCGM.EXPECT().UpdateAllFields().Return(nil)
+	mockDCGM.EXPECT().GetValuesSince(mockGroupHandle, mockFieldGroupHandle,
+		gomock.AssignableToTypeOf(time.Time{})).Return(mockEntitiesResult, time.Time{}, nil)
+	mockDCGM.EXPECT().EntityGetLatestValues(dcgm.FE_GPU, gpuID0, []dcgm.Short{labelFieldID}).
+		Return(labelValuesFor(gpu0Label), nil)
+	mockDCGM.EXPECT().EntityGetLatestValues(dcgm.FE_GPU, gpuID1, []dcgm.Short{labelFieldID}).
+		Return(labelValuesFor(gpu1Label), nil)
+
+	counterList := counters.CounterList{xidCounter, labelCounter}
+	deviceWatchList := devicewatchlistmanager.NewWatchList(mockGPUDeviceInfo, []dcgm.Short{42},
+		[]dcgm.Short{labelFieldID}, mockDeviceWatcher, int64(1))
+
+	config := appconfig.Config{}
+	collector, err := NewXIDCollector(counterList, "localhost", &config, *deviceWatchList)
+	assert.NoError(t, err)
+
+	got, err := collector.GetMetrics()
+	assert.NoError(t, err)
+
+	metrics := got[xidCounter]
+	assert.Len(t, metrics, 2)
+
+	byGPU := map[string]Metric{}
+	for _, m := range metrics {
+		byGPU[m.GPU] = m
+	}
+
+	// The idle GPU0 must keep its own label, not inherit GPU1's.
+	assert.Equal(t, gpu0Label, byGPU["0"].Labels[labelName],
+		"idle GPU label bled from another entity via a shared label map")
+	assert.Equal(t, gpu1Label, byGPU["1"].Labels[labelName])
+}


### PR DESCRIPTION
## Problem

The experimental collectors (XID, clock events, GPU health, P2P status)
build a single label map before the per-entity loop and reuse it for every
GPU. `getLabelsFromCounters` only adds label keys, so keys set for one GPU
leak onto GPUs that lack them.

In `expcollector.go` the idle/zero-value branch passes that shared map
directly to `createMetric`, which stores it by reference (`Labels: labels`).
The next entity's `getLabelsFromCounters` then mutates the same map, so an
idle GPU ends up reporting another GPU's label values.

## Fix

Allocate the label map inside the per-entity loop in `expcollector.go`,
`gpu_health_collector.go`, and `p2p_status_collector.go`, so each entity
starts with its own labels.

## Test

`Test_xidCollector_GetMetrics_PerEntityLabelIsolation` sets up two GPUs with
distinct label values where only one GPU has an XID event, forcing the other
down the idle branch. It fails on `main` (the idle GPU reports the other
GPU's label) and passes with this change.

```
go test ./internal/pkg/collector/
ok  github.com/NVIDIA/dcgm-exporter/internal/pkg/collector
```
