### PR TITLE
Add v1 api support for dra-driver-nvidia-gpu

### DIFF
--- a/internal/pkg/transformation/dra.go
+++ b/internal/pkg/transformation/dra.go
@@ -22,8 +22,13 @@ import (
 	"log/slog"
 	"time"
 
+	resourcev1 "k8s.io/api/resource/v1"
 	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	resourcelistersv1 "k8s.io/client-go/listers/resource/v1"
+	resourcelistersv1beta1 "k8s.io/client-go/listers/resource/v1beta1"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/kubeclient"
@@ -31,7 +36,65 @@ import (
 
 const (
 	informerResyncPeriod = 10 * time.Minute
+
+	// resourceSliceCacheSyncTimeout bounds how long we wait for the initial
+	// ResourceSlice informer cache sync. Discovery may report that v1 (or
+	// v1beta1) is served while RBAC denies list/watch on resourceslices; in
+	// that case the informer's reflector retries forever and HasSynced never
+	// returns true. A bounded wait prevents the exporter from blocking on
+	// startup in such misconfigurations.
+	resourceSliceCacheSyncTimeout = 30 * time.Second
 )
+
+// resourceSliceAPIVersion identifies which ResourceSlice API version the cluster serves.
+type resourceSliceAPIVersion int
+
+const (
+	resourceSliceAPIUnknown resourceSliceAPIVersion = iota
+	resourceSliceAPIV1
+	resourceSliceAPIV1beta1
+)
+
+func (v resourceSliceAPIVersion) String() string {
+	switch v {
+	case resourceSliceAPIV1:
+		return resourcev1.SchemeGroupVersion.String()
+	case resourceSliceAPIV1beta1:
+		return resourcev1beta1.SchemeGroupVersion.String()
+	default:
+		return "unknown"
+	}
+}
+
+// detectResourceSliceAPIVersion returns the ResourceSlice API version served by
+// the cluster. It uses discovery to look for the resourceslices resource under
+// resource.k8s.io/v1 first (stable, Kubernetes 1.34+) and falls back to
+// resource.k8s.io/v1beta1 (older clusters). Returns resourceSliceAPIUnknown if
+// neither GroupVersion is served.
+func detectResourceSliceAPIVersion(client kubernetes.Interface) resourceSliceAPIVersion {
+	apiVersion := []struct {
+		groupVersion string
+		version      resourceSliceAPIVersion
+	}{
+		{resourcev1.SchemeGroupVersion.WithResource("resourceslices").GroupVersion().String(), resourceSliceAPIV1},
+		{resourcev1beta1.SchemeGroupVersion.WithResource("resourceslices").GroupVersion().String(), resourceSliceAPIV1beta1},
+	}
+
+	for _, a := range apiVersion {
+		resources, err := client.Discovery().ServerResourcesForGroupVersion(a.groupVersion)
+		if err != nil {
+			// Discovery returns an error when the group/version isn't served.
+			slog.Debug("ResourceSlice discovery failed", "groupVersion", a.groupVersion, "error", err)
+			continue
+		}
+		for _, r := range resources.APIResources {
+			if r.Name == "resourceslices" {
+				return a.version
+			}
+		}
+	}
+	return resourceSliceAPIUnknown
+}
 
 func NewDRAResourceSliceManager() (*DRAResourceSliceManager, error) {
 	client, err := kubeclient.GetKubeClient()
@@ -39,37 +102,47 @@ func NewDRAResourceSliceManager() (*DRAResourceSliceManager, error) {
 		return nil, fmt.Errorf("error getting kube client: %w", err)
 	}
 
+	apiVersion := detectResourceSliceAPIVersion(client)
+	if apiVersion == resourceSliceAPIUnknown {
+		return nil, fmt.Errorf("ResourceSlice API not served by cluster (looked for %s and %s)",
+			resourcev1.SchemeGroupVersion, resourcev1beta1.SchemeGroupVersion)
+	}
+
 	factory := informers.NewSharedInformerFactory(client, informerResyncPeriod)
-	informer := factory.Resource().V1beta1().ResourceSlices().Informer()
 
-	m := &DRAResourceSliceManager{
-		factory:      factory,
-		informer:     informer,
-		deviceToUUID: make(map[string]string),
-		migDevices:   make(map[string]*DRAMigDeviceInfo),
+	m := &DRAResourceSliceManager{factory: factory}
+
+	var hasSynced cache.InformerSynced
+	switch apiVersion {
+	case resourceSliceAPIV1:
+		informer := factory.Resource().V1().ResourceSlices().Informer()
+		lister := factory.Resource().V1().ResourceSlices().Lister()
+		m.lookup = makeV1Lookup(lister)
+		hasSynced = informer.HasSynced
+	case resourceSliceAPIV1beta1:
+		informer := factory.Resource().V1beta1().ResourceSlices().Informer()
+		lister := factory.Resource().V1beta1().ResourceSlices().Lister()
+		m.lookup = makeV1beta1Lookup(lister)
+		hasSynced = informer.HasSynced
 	}
 
-	_, err = informer.AddEventHandler(&cache.FilteringResourceEventHandler{
-		FilterFunc: func(obj interface{}) bool {
-			s := obj.(*resourcev1beta1.ResourceSlice)
-			return s.Spec.Driver == DRAGPUDriverName
-		},
-		Handler: cache.ResourceEventHandlerFuncs{
-			AddFunc:    m.onAddOrUpdate,
-			UpdateFunc: func(_, o interface{}) { m.onAddOrUpdate(o) },
-			DeleteFunc: m.onDelete,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("error adding event handler: %w", err)
-	}
+	slog.Info("Using ResourceSlice API", "groupVersion", apiVersion.String())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancelContext = cancel
 	factory.Start(ctx.Done())
 
-	if !cache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+	// Bound the initial sync. Discovery may say the API is served, but RBAC
+	// can still deny list/watch on resourceslices, in which case HasSynced
+	// would never become true and startup would hang.
+	syncCtx, syncCancel := context.WithTimeout(ctx, resourceSliceCacheSyncTimeout)
+	defer syncCancel()
+	if !cache.WaitForCacheSync(syncCtx.Done(), hasSynced) {
 		cancel()
+		if syncCtx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("ResourceSlice informer cache sync timed out after %s "+
+				"(check RBAC: list/watch on resource.k8s.io/resourceslices)", resourceSliceCacheSyncTimeout)
+		}
 		return nil, fmt.Errorf("ResourceSlice informer cache sync failed")
 	}
 	return m, nil
@@ -79,100 +152,123 @@ func (m *DRAResourceSliceManager) Stop() {
 	if m.cancelContext != nil {
 		m.cancelContext()
 	}
-	// Ensure factory informers are fully stopped
+	// Ensure factory informers are fully stopped.
 	if m.factory != nil {
 		m.factory.Shutdown()
 	}
 }
 
-// GetDeviceInfo returns the mapping UUID and MIG device info if applicable
-// For MIG devices: returns (parentUUID, *DRAMigDeviceInfo)
-// For full GPUs: returns (deviceUUID, nil)
+// GetDeviceInfo returns the mapping UUID and MIG device info if applicable.
+// For MIG devices: returns (parentUUID, *DRAMigDeviceInfo).
+// For full GPUs:  returns (deviceUUID, nil).
+// If the (pool, device) tuple is not known, returns ("", nil).
 func (m *DRAResourceSliceManager) GetDeviceInfo(pool, device string) (string, *DRAMigDeviceInfo) {
-	key := pool + "/" + device
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	// Check if this is a MIG device
-	if migInfo, exists := m.migDevices[key]; exists {
-		// MIG device - return parent UUID and MIG info
-		slog.Debug(fmt.Sprintf("Found MIG device for %s with parent UUID: %s", key, migInfo.ParentUUID))
-		return migInfo.ParentUUID, migInfo
+	if m.lookup == nil {
+		return "", nil
 	}
-
-	// Full GPU device - return device UUID with no MIG info
-	if uuid, exists := m.deviceToUUID[key]; exists {
-		slog.Debug(fmt.Sprintf("Found GPU device for %s with UUID: %s", uuid, key))
-		return uuid, nil
-	}
-
-	slog.Info(fmt.Sprintf("No UUID found for %s", key))
-	return "", nil
+	return m.lookup(pool, device)
 }
 
-func getAttrString(attrs map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute, key resourcev1beta1.QualifiedName) string {
+// deviceLookupFunc resolves a (pool, device) tuple to a primary mapping UUID
+// and optional MIG info using the version-specific Lister cache. Versions
+// differ in their attribute layout (v1 stores attributes directly on the
+// device; v1beta1 wraps them under .Basic), so each version supplies its own
+// implementation.
+type deviceLookupFunc func(pool, device string) (string, *DRAMigDeviceInfo)
+
+func makeV1Lookup(lister resourcelistersv1.ResourceSliceLister) deviceLookupFunc {
+	return func(pool, device string) (string, *DRAMigDeviceInfo) {
+		slices, err := lister.List(labels.Everything())
+		if err != nil {
+			slog.Debug("listing v1 ResourceSlices failed", "error", err)
+			return "", nil
+		}
+		for _, s := range slices {
+			if s.Spec.Driver != DRAGPUDriverName || s.Spec.Pool.Name != pool {
+				continue
+			}
+			for _, d := range s.Spec.Devices {
+				if d.Name != device {
+					continue
+				}
+				if d.Attributes == nil {
+					return "", nil
+				}
+				return buildDeviceMapping(
+					getV1AttrString(d.Attributes, "type"),
+					getV1AttrString(d.Attributes, "uuid"),
+					getV1AttrString(d.Attributes, "parentUUID"),
+					getV1AttrString(d.Attributes, "profile"),
+				)
+			}
+		}
+		return "", nil
+	}
+}
+
+func makeV1beta1Lookup(lister resourcelistersv1beta1.ResourceSliceLister) deviceLookupFunc {
+	return func(pool, device string) (string, *DRAMigDeviceInfo) {
+		slices, err := lister.List(labels.Everything())
+		if err != nil {
+			slog.Debug("listing v1beta1 ResourceSlices failed", "error", err)
+			return "", nil
+		}
+		for _, s := range slices {
+			if s.Spec.Driver != DRAGPUDriverName || s.Spec.Pool.Name != pool {
+				continue
+			}
+			for _, d := range s.Spec.Devices {
+				if d.Name != device {
+					continue
+				}
+				if d.Basic == nil || d.Basic.Attributes == nil {
+					return "", nil
+				}
+				return buildDeviceMapping(
+					getV1beta1AttrString(d.Basic.Attributes, "type"),
+					getV1beta1AttrString(d.Basic.Attributes, "uuid"),
+					getV1beta1AttrString(d.Basic.Attributes, "parentUUID"),
+					getV1beta1AttrString(d.Basic.Attributes, "profile"),
+				)
+			}
+		}
+		return "", nil
+	}
+}
+
+// buildDeviceMapping converts the four DRA attributes that dcgm-exporter
+// cares about into the (uuid, *MIGInfo). Returns
+// ("", nil) for an unknown device type or a malformed MIG entry.
+func buildDeviceMapping(deviceType, uuid, parentUUID, profile string) (string, *DRAMigDeviceInfo) {
+	switch deviceType {
+	case "gpu":
+		return uuid, nil
+	case "mig":
+		if parentUUID == "" {
+			slog.Debug("MIG device missing parent UUID", "uuid", uuid)
+			return "", nil
+		}
+		return parentUUID, &DRAMigDeviceInfo{
+			MIGDeviceUUID: uuid,
+			Profile:       profile,
+			ParentUUID:    parentUUID,
+		}
+	default:
+		slog.Debug("Unknown DRA device type", "type", deviceType)
+		return "", nil
+	}
+}
+
+func getV1AttrString(attrs map[resourcev1.QualifiedName]resourcev1.DeviceAttribute, key resourcev1.QualifiedName) string {
 	if attr, ok := attrs[key]; ok && attr.StringValue != nil {
 		return *attr.StringValue
 	}
 	return ""
 }
 
-func (m *DRAResourceSliceManager) onAddOrUpdate(obj interface{}) {
-	slice := obj.(*resourcev1beta1.ResourceSlice)
-	pool := slice.Spec.Pool.Name
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for _, dev := range slice.Spec.Devices {
-		if dev.Basic == nil || dev.Basic.Attributes == nil {
-			continue
-		}
-		key := pool + "/" + dev.Name
-		attr := dev.Basic.Attributes
-
-		deviceType := getAttrString(attr, "type")
-		switch deviceType {
-		case "gpu":
-			if uuid := getAttrString(attr, "uuid"); uuid != "" {
-				m.deviceToUUID[key] = uuid
-				slog.Debug(fmt.Sprintf("Added gpu device [key:%s] with UUID: %s", key, uuid))
-			}
-
-		case "mig":
-			parentUUID := getAttrString(attr, "parentUUID")
-			profile := getAttrString(attr, "profile")
-			migUUID := getAttrString(attr, "uuid")
-
-			// Only create MIG device if we have required parent UUID
-			if parentUUID != "" {
-				m.migDevices[key] = &DRAMigDeviceInfo{
-					MIGDeviceUUID: migUUID,
-					Profile:       profile,
-					ParentUUID:    parentUUID,
-				}
-				slog.Debug(fmt.Sprintf("Added MIG device %s (profile: %s) with parent: %s", migUUID, profile, parentUUID))
-			} else {
-				slog.Debug(fmt.Sprintf("MIG device %s missing parent UUID", migUUID))
-			}
-
-		default:
-			slog.Warn(fmt.Sprintf("Device [key:%s] has unknown type: %s", key, deviceType))
-		}
+func getV1beta1AttrString(attrs map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute, key resourcev1beta1.QualifiedName) string {
+	if attr, ok := attrs[key]; ok && attr.StringValue != nil {
+		return *attr.StringValue
 	}
-}
-
-func (m *DRAResourceSliceManager) onDelete(obj interface{}) {
-	slice := obj.(*resourcev1beta1.ResourceSlice)
-	pool := slice.Spec.Pool.Name
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for _, dev := range slice.Spec.Devices {
-		key := pool + "/" + dev.Name
-		slog.Debug(fmt.Sprintf("Removing device for %s", key))
-		delete(m.deviceToUUID, key)
-		delete(m.migDevices, key)
-	}
+	return ""
 }

--- a/internal/pkg/transformation/dra_test.go
+++ b/internal/pkg/transformation/dra_test.go
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package transformation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	resourcev1 "k8s.io/api/resource/v1"
+	resourcev1beta1 "k8s.io/api/resource/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	resourcelistersv1 "k8s.io/client-go/listers/resource/v1"
+	resourcelistersv1beta1 "k8s.io/client-go/listers/resource/v1beta1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// resourceSlicesAPIResource is the metadata that ServerResourcesForGroupVersion
+// returns when a cluster serves the resourceslices resource. We use it in
+// detectResourceSliceAPIVersion tests to simulate which API versions the
+// server advertises.
+var resourceSlicesAPIResource = metav1.APIResource{
+	Name:       "resourceslices",
+	Namespaced: false,
+	Kind:       "ResourceSlice",
+}
+
+func TestDetectResourceSliceAPIVersion(t *testing.T) {
+	v1GV := resourcev1.SchemeGroupVersion.String()
+	v1beta1GV := resourcev1beta1.SchemeGroupVersion.String()
+
+	tests := []struct {
+		name      string
+		resources []*metav1.APIResourceList
+		want      resourceSliceAPIVersion
+	}{
+		{
+			name: "v1-only",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1GV,
+					APIResources: []metav1.APIResource{resourceSlicesAPIResource},
+				},
+			},
+			want: resourceSliceAPIV1,
+		},
+		{
+			name: "v1beta1-only",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1beta1GV,
+					APIResources: []metav1.APIResource{resourceSlicesAPIResource},
+				},
+			},
+			want: resourceSliceAPIV1beta1,
+		},
+		{
+			name: "both-served-prefers-v1",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1GV,
+					APIResources: []metav1.APIResource{resourceSlicesAPIResource},
+				},
+				{
+					GroupVersion: v1beta1GV,
+					APIResources: []metav1.APIResource{resourceSlicesAPIResource},
+				},
+			},
+			want: resourceSliceAPIV1,
+		},
+		{
+			name:      "neither-served",
+			resources: nil,
+			want:      resourceSliceAPIUnknown,
+		},
+		{
+			// v1 group is advertised but the resourceslices resource itself
+			// is not in the list. Detection must skip v1 (inner-loop check)
+			// and fall back to v1beta1.
+			name: "v1-group-without-resourceslices-falls-back-to-v1beta1",
+			resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: v1GV,
+					APIResources: []metav1.APIResource{
+						{Name: "deviceclasses", Namespaced: false, Kind: "DeviceClass"},
+					},
+				},
+				{
+					GroupVersion: v1beta1GV,
+					APIResources: []metav1.APIResource{resourceSlicesAPIResource},
+				},
+			},
+			want: resourceSliceAPIV1beta1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			client.Resources = tc.resources
+
+			got := detectResourceSliceAPIVersion(client)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestBuildDeviceMapping(t *testing.T) {
+	tests := []struct {
+		name        string
+		deviceType  string
+		uuid        string
+		parentUUID  string
+		profile     string
+		wantUUID    string
+		wantMIGInfo *DRAMigDeviceInfo
+	}{
+		{
+			name:        "full-gpu",
+			deviceType:  "gpu",
+			uuid:        "GPU-abcd",
+			wantUUID:    "GPU-abcd",
+			wantMIGInfo: nil,
+		},
+		{
+			name:       "mig-with-parent",
+			deviceType: "mig",
+			uuid:       "MIG-1234",
+			parentUUID: "GPU-parent",
+			profile:    "1g.6gb",
+			wantUUID:   "GPU-parent",
+			wantMIGInfo: &DRAMigDeviceInfo{
+				MIGDeviceUUID: "MIG-1234",
+				Profile:       "1g.6gb",
+				ParentUUID:    "GPU-parent",
+			},
+		},
+		{
+			// A MIG entry without parentUUID is malformed; the function must
+			// drop it rather than registering a series under an empty key.
+			name:        "mig-missing-parent",
+			deviceType:  "mig",
+			uuid:        "MIG-orphan",
+			wantUUID:    "",
+			wantMIGInfo: nil,
+		},
+		{
+			name:        "unknown-type",
+			deviceType:  "tpu",
+			uuid:        "TPU-xyz",
+			wantUUID:    "",
+			wantMIGInfo: nil,
+		},
+		{
+			name:        "empty-type",
+			deviceType:  "",
+			uuid:        "GPU-abcd",
+			wantUUID:    "",
+			wantMIGInfo: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUUID, gotMIG := buildDeviceMapping(tc.deviceType, tc.uuid, tc.parentUUID, tc.profile)
+			assert.Equal(t, tc.wantUUID, gotUUID)
+			assert.Equal(t, tc.wantMIGInfo, gotMIG)
+		})
+	}
+}
+
+func TestMakeV1Lookup(t *testing.T) {
+	stringPtr := func(s string) *string { return &s }
+	gpuAttrs := map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+		"type": {StringValue: stringPtr("gpu")},
+		"uuid": {StringValue: stringPtr("GPU-aaaa")},
+	}
+	migAttrs := map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+		"type":       {StringValue: stringPtr("mig")},
+		"uuid":       {StringValue: stringPtr("MIG-bbbb")},
+		"parentUUID": {StringValue: stringPtr("GPU-aaaa")},
+		"profile":    {StringValue: stringPtr("1g.6gb")},
+	}
+
+	gpuSlice := &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-gpu"},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: DRAGPUDriverName,
+			Pool:   resourcev1.ResourcePool{Name: "node-a"},
+			Devices: []resourcev1.Device{
+				{Name: "gpu-0", Attributes: gpuAttrs},
+				{Name: "gpu-1-mig-0", Attributes: migAttrs},
+				{Name: "gpu-no-attrs"},
+			},
+		},
+	}
+	// Slice belongs to a different driver but shares the pool. The lookup
+	// must skip it because lookups are scoped to gpu.nvidia.com.
+	otherDriverSlice := &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-other-driver"},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: "other.example.com",
+			Pool:   resourcev1.ResourcePool{Name: "node-a"},
+			Devices: []resourcev1.Device{
+				{Name: "non-nvidia-device", Attributes: gpuAttrs},
+			},
+		},
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(gpuSlice))
+	require.NoError(t, indexer.Add(otherDriverSlice))
+	lookup := makeV1Lookup(resourcelistersv1.NewResourceSliceLister(indexer))
+
+	tests := []struct {
+		name        string
+		pool        string
+		device      string
+		wantUUID    string
+		wantMIGInfo *DRAMigDeviceInfo
+	}{
+		{
+			name:     "gpu-device-resolves-to-uuid",
+			pool:     "node-a",
+			device:   "gpu-0",
+			wantUUID: "GPU-aaaa",
+		},
+		{
+			name:     "mig-device-resolves-to-parent-uuid-with-mig-info",
+			pool:     "node-a",
+			device:   "gpu-1-mig-0",
+			wantUUID: "GPU-aaaa",
+			wantMIGInfo: &DRAMigDeviceInfo{
+				MIGDeviceUUID: "MIG-bbbb",
+				Profile:       "1g.6gb",
+				ParentUUID:    "GPU-aaaa",
+			},
+		},
+		{
+			// Device exists in the indexer but only on a slice owned by a
+			// non-NVIDIA driver. If the driver filter regresses, the lookup
+			// would return GPU-aaaa instead of "".
+			name:     "different-driver-not-matched",
+			pool:     "node-a",
+			device:   "non-nvidia-device",
+			wantUUID: "",
+		},
+		{
+			name:     "unknown-pool",
+			pool:     "node-z",
+			device:   "gpu-0",
+			wantUUID: "",
+		},
+		{
+			name:     "unknown-device",
+			pool:     "node-a",
+			device:   "gpu-99",
+			wantUUID: "",
+		},
+		{
+			name:     "device-without-attributes",
+			pool:     "node-a",
+			device:   "gpu-no-attrs",
+			wantUUID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUUID, gotMIG := lookup(tc.pool, tc.device)
+			assert.Equal(t, tc.wantUUID, gotUUID)
+			assert.Equal(t, tc.wantMIGInfo, gotMIG)
+		})
+	}
+}
+
+func TestMakeV1beta1Lookup(t *testing.T) {
+	stringPtr := func(s string) *string { return &s }
+	gpuAttrs := map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute{
+		"type": {StringValue: stringPtr("gpu")},
+		"uuid": {StringValue: stringPtr("GPU-aaaa")},
+	}
+	migAttrs := map[resourcev1beta1.QualifiedName]resourcev1beta1.DeviceAttribute{
+		"type":       {StringValue: stringPtr("mig")},
+		"uuid":       {StringValue: stringPtr("MIG-bbbb")},
+		"parentUUID": {StringValue: stringPtr("GPU-aaaa")},
+		"profile":    {StringValue: stringPtr("1g.6gb")},
+	}
+
+	gpuSlice := &resourcev1beta1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-gpu"},
+		Spec: resourcev1beta1.ResourceSliceSpec{
+			Driver: DRAGPUDriverName,
+			Pool:   resourcev1beta1.ResourcePool{Name: "node-a"},
+			Devices: []resourcev1beta1.Device{
+				{Name: "gpu-0", Basic: &resourcev1beta1.BasicDevice{Attributes: gpuAttrs}},
+				{Name: "gpu-1-mig-0", Basic: &resourcev1beta1.BasicDevice{Attributes: migAttrs}},
+				// nil Basic is the v1beta1 analogue of "no attributes": must
+				// not panic and must return ("", nil).
+				{Name: "gpu-no-basic"},
+			},
+		},
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(gpuSlice))
+	lookup := makeV1beta1Lookup(resourcelistersv1beta1.NewResourceSliceLister(indexer))
+
+	tests := []struct {
+		name        string
+		pool        string
+		device      string
+		wantUUID    string
+		wantMIGInfo *DRAMigDeviceInfo
+	}{
+		{
+			name:     "gpu-device-resolves-to-uuid",
+			pool:     "node-a",
+			device:   "gpu-0",
+			wantUUID: "GPU-aaaa",
+		},
+		{
+			name:     "mig-device-resolves-to-parent-uuid-with-mig-info",
+			pool:     "node-a",
+			device:   "gpu-1-mig-0",
+			wantUUID: "GPU-aaaa",
+			wantMIGInfo: &DRAMigDeviceInfo{
+				MIGDeviceUUID: "MIG-bbbb",
+				Profile:       "1g.6gb",
+				ParentUUID:    "GPU-aaaa",
+			},
+		},
+		{
+			name:     "device-without-basic",
+			pool:     "node-a",
+			device:   "gpu-no-basic",
+			wantUUID: "",
+		},
+		{
+			name:     "unknown-device",
+			pool:     "node-a",
+			device:   "gpu-99",
+			wantUUID: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotUUID, gotMIG := lookup(tc.pool, tc.device)
+			assert.Equal(t, tc.wantUUID, gotUUID)
+			assert.Equal(t, tc.wantMIGInfo, gotMIG)
+		})
+	}
+}
+
+func TestDRAResourceSliceManager_GetDeviceInfo_NilLookup(t *testing.T) {
+	// in case of partial init failure, must not
+	// panic when GetDeviceInfo is called; it should report "not found".
+	m := &DRAResourceSliceManager{}
+	uuid, mig := m.GetDeviceInfo("any-pool", "any-device")
+	assert.Empty(t, uuid)
+	assert.Nil(t, mig)
+}

--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -322,7 +322,7 @@ func (p *PodMapper) getMappings(deviceInfo deviceinfo.Provider) (map[string][]Po
 	}
 
 	if p.Config.KubernetesEnableDRA {
-		deviceToPodsDRA = p.toDeviceToPodsDRA(pods)
+		deviceToPodsDRA = p.toDeviceToPodsDRA(pods, deviceInfo)
 	}
 
 	return deviceToPods, deviceToPod, deviceToPodsDRA, nil
@@ -570,12 +570,12 @@ func stripVGPUSuffix(deviceID string) string {
 	return deviceID
 }
 
-func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourcesResponse) map[string][]PodInfo {
+func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourcesResponse, deviceInfo deviceinfo.Provider) map[string][]PodInfo {
 	deviceToPodsMap := make(map[string][]PodInfo)
 
 	slog.Debug("Processing pod dynamic resources", "totalPods", len(devicePods.GetPodResources()))
 	// Track pod+namespace+container combinations per device
-	// UUID -> "podName/namespace/containerName" -> bool
+	// draMappingKey -> "podName/namespace/containerName" -> bool
 	processedPods := make(map[string]map[string]bool)
 
 	for _, pod := range devicePods.GetPodResources() {
@@ -603,18 +603,21 @@ func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourc
 							continue
 						}
 
-						// Create unique key for pod+namespace+container combination
+						// Build the set of DRA mapping keys under which this
+						// pod/container must be discoverable. DCGM emits
+						// MIG-instance metrics keyed by "<gpuIndex>-<gpuInstanceID>"
+						// (see Metric.GetIDOfType), so for MIG claims we
+						// additionally register the GPU-instance identifier in
+						// addition to the parent UUID. Without this, per-MIG
+						// metrics never receive pod attributes.
+						draMappingKeys := []string{mappingKey}
+						if migInfo != nil {
+							if giID := p.draMIGGPUInstanceIdentifier(migInfo, deviceInfo); giID != "" {
+								draMappingKeys = append(draMappingKeys, giID)
+							}
+						}
+
 						podContainerKey := podName + "/" + podNamespace + "/" + cntName
-
-						// Initialize tracker for this device if needed
-						if processedPods[mappingKey] == nil {
-							processedPods[mappingKey] = make(map[string]bool)
-						}
-
-						// Skip if we already processed this pod+container for this device
-						if processedPods[mappingKey][podContainerKey] {
-							continue
-						}
 
 						podInfo := p.createPodInfo(pod, container)
 						drInfo := DynamicResourceInfo{
@@ -628,6 +631,7 @@ func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourc
 							drInfo.MIGInfo = migInfo
 							slog.Debug("Added MIG pod mapping",
 								"parentUUID", mappingKey,
+								"draMappingKeys", draMappingKeys,
 								"migDevice", migInfo.MIGDeviceUUID,
 								"migProfile", migInfo.Profile,
 								"pod", podContainerKey)
@@ -638,8 +642,16 @@ func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourc
 						}
 
 						podInfo.DynamicResources = &drInfo
-						deviceToPodsMap[mappingKey] = append(deviceToPodsMap[mappingKey], podInfo)
-						processedPods[mappingKey][podContainerKey] = true
+						for _, key := range draMappingKeys {
+							if processedPods[key] == nil {
+								processedPods[key] = make(map[string]bool)
+							}
+							if processedPods[key][podContainerKey] {
+								continue
+							}
+							deviceToPodsMap[key] = append(deviceToPodsMap[key], podInfo)
+							processedPods[key][podContainerKey] = true
+						}
 					}
 				}
 			}
@@ -650,6 +662,29 @@ func (p *PodMapper) toDeviceToPodsDRA(devicePods *podresourcesapi.ListPodResourc
 		"totalMappings", len(deviceToPodsMap),
 		"deviceToPodsMap", fmt.Sprintf("%+v", deviceToPodsMap))
 	return deviceToPodsMap
+}
+
+// draMIGGPUInstanceIdentifier returns the "<gpuIndex>-<gpuInstanceID>" join
+// key that DCGM uses for per-MIG-instance metrics. The MIG GPU-instance ID is
+// not exposed as a DRA device attribute today, so we look it up via NVML using
+// the MIG UUID published by the DRA driver. Returns "" when NVML or
+// deviceInfo are unavailable, or when the MIG UUID cannot be resolved; in
+// that case the caller falls back to the parent-UUID join key only.
+func (p *PodMapper) draMIGGPUInstanceIdentifier(migInfo *DRAMigDeviceInfo, deviceInfo deviceinfo.Provider) string {
+	if migInfo == nil || deviceInfo == nil || migInfo.MIGDeviceUUID == "" {
+		return ""
+	}
+	migDevice, err := nvmlprovider.Client().GetMIGDeviceInfoByID(migInfo.MIGDeviceUUID)
+	if err != nil {
+		slog.Warn("DRA: NVML lookup for MIG device failed; per-MIG metrics will not be enriched with pod labels",
+			"migUUID", migInfo.MIGDeviceUUID, "error", err)
+		return ""
+	}
+	if migDevice.GPUInstanceID < 0 {
+		return ""
+	}
+	return deviceinfo.GetGPUInstanceIdentifier(deviceInfo, migDevice.ParentUUID,
+		uint(migDevice.GPUInstanceID)) //nolint:gosec // G115: bounds checked above
 }
 
 // toDeviceToSharingPods uses the same general logic as toDeviceToPod but

--- a/internal/pkg/transformation/kubernetes_test.go
+++ b/internal/pkg/transformation/kubernetes_test.go
@@ -636,55 +636,52 @@ func TestPodDRAInfo(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		deviceToUUID map[string]string
-		migDevices   map[string]*DRAMigDeviceInfo
-		wantUUIDs    []string
-		isMIG        bool
+		name      string
+		uuid      string
+		mig       *DRAMigDeviceInfo
+		wantUUIDs []string
+		isMIG     bool
 	}{
 		{
-			name:         "uuid-exists",
-			deviceToUUID: map[string]string{"poolA/gpu-x": "GPU-8a748984-0fe7-297f-916c-4b998ce202d1"},
-			migDevices:   map[string]*DRAMigDeviceInfo{},
-			wantUUIDs:    []string{"GPU-8a748984-0fe7-297f-916c-4b998ce202d1"},
-			isMIG:        false,
+			name:      "uuid-exists",
+			uuid:      "GPU-8a748984-0fe7-297f-916c-4b998ce202d1",
+			wantUUIDs: []string{"GPU-8a748984-0fe7-297f-916c-4b998ce202d1"},
 		},
 		{
-			name:         "uuid-updated",
-			deviceToUUID: map[string]string{"poolA/gpu-x": "GPU-UUID-Updated"},
-			migDevices:   map[string]*DRAMigDeviceInfo{},
-			wantUUIDs:    []string{"GPU-UUID-Updated"},
-			isMIG:        false,
+			name:      "uuid-updated",
+			uuid:      "GPU-UUID-Updated",
+			wantUUIDs: []string{"GPU-UUID-Updated"},
 		},
 		{
-			name:         "no-uuid",
-			deviceToUUID: map[string]string{},
-			migDevices:   map[string]*DRAMigDeviceInfo{},
-			wantUUIDs:    nil,
-			isMIG:        false,
+			name:      "no-uuid",
+			uuid:      "",
+			wantUUIDs: nil,
 		},
 		{
-			name:         "mig-device",
-			deviceToUUID: map[string]string{"poolA/gpu-x": "MIG-12345"},
-			migDevices: map[string]*DRAMigDeviceInfo{
-				"poolA/gpu-x": {
-					MIGDeviceUUID: "MIG-12345",
-					Profile:       "1g.12gb",
-					ParentUUID:    "GPU-parent-uuid",
-				},
+			name: "mig-device",
+			uuid: "GPU-parent-uuid",
+			mig: &DRAMigDeviceInfo{
+				MIGDeviceUUID: "MIG-12345",
+				Profile:       "1g.12gb",
+				ParentUUID:    "GPU-parent-uuid",
 			},
-			wantUUIDs: []string{"GPU-parent-uuid"}, // Should map to parent UUID
+			wantUUIDs: []string{"GPU-parent-uuid"},
 			isMIG:     true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Inject a stub lookup. This mirrors what the real v1/v1beta1
+			// Lister-backed lookups return for a single (pool, device) tuple.
 			draMgr := &DRAResourceSliceManager{
-				deviceToUUID: tc.deviceToUUID,
-				migDevices:   tc.migDevices,
+				lookup: func(pool, device string) (string, *DRAMigDeviceInfo) {
+					if pool == "poolA" && device == "gpu-x" {
+						return tc.uuid, tc.mig
+					}
+					return "", nil
+				},
 			}
-
 			pm := &PodMapper{
 				Config:               &appconfig.Config{NvidiaResourceNames: []string{appconfig.NvidiaResourceName}},
 				ResourceSliceManager: draMgr,
@@ -701,7 +698,10 @@ func TestPodDRAInfo(t *testing.T) {
 				}},
 			}
 
-			got := pm.toDeviceToPodsDRA(resp)
+			// deviceInfo is nil here: the existing cases don't exercise the
+			// MIG path. NVML lookup is skipped when deviceInfo is nil,
+			// so the function falls back to parent-UUID-only mapping
+			got := pm.toDeviceToPodsDRA(resp, nil)
 
 			assert.Len(t, got, len(tc.wantUUIDs), "map size")
 			for _, want := range tc.wantUUIDs {

--- a/internal/pkg/transformation/kubernetes_test.go
+++ b/internal/pkg/transformation/kubernetes_test.go
@@ -734,6 +734,250 @@ func TestPodDRAInfo(t *testing.T) {
 	}
 }
 
+// TestPodDRAInfo_MIGAddsGPUInstanceMapping covers the MIG fan-out path of
+// toDeviceToPodsDRA: a DRA MIG claim must register the pod under both the
+// parent GPU UUID and DCGM's per-MIG metric key "<gpuIdx>-<gpuInstanceID>".
+// The previous test passes nil deviceInfo, which short-circuits NVML lookup
+// and only exercises the parent-UUID fallback. Without the second key the
+// per-MIG DCGM metrics (DCGM_FI_DEV_*) never receive pod/DRA labels.
+func TestPodDRAInfo_MIGAddsGPUInstanceMapping(t *testing.T) {
+	const (
+		parentUUID    = "GPU-parent-uuid"
+		migUUID       = "MIG-12345"
+		migProfile    = "1g.12gb"
+		gpuInstanceID = 3
+		gpuIndex      = uint(0)
+	)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// NVML resolves a MIG UUID to its parent GPU UUID and instance ID. The
+	// transformation code uses this to construct the "<gpuIdx>-<giID>" key.
+	mockNVML := mocknvmlprovider.NewMockNVML(ctrl)
+	mockNVML.EXPECT().GetMIGDeviceInfoByID(migUUID).Return(&nvmlprovider.MIGDeviceInfo{
+		ParentUUID:    parentUUID,
+		GPUInstanceID: gpuInstanceID,
+	}, nil).AnyTimes()
+	originalNVML := nvmlprovider.Client()
+	defer nvmlprovider.SetClient(originalNVML)
+	nvmlprovider.SetClient(mockNVML)
+
+	// deviceinfo.Provider is walked to find the GPU index whose UUID matches
+	// the parent. We expose a single GPU at index 0 with the matching UUID.
+	mockDeviceInfo := mockdeviceinfo.NewMockProvider(ctrl)
+	mockDeviceInfo.EXPECT().GPUCount().Return(toUint(1)).AnyTimes()
+	mockDeviceInfo.EXPECT().GPU(gpuIndex).Return(deviceinfo.GPUInfo{
+		DeviceInfo: dcgm.Device{UUID: parentUUID, GPU: gpuIndex},
+		MigEnabled: true,
+	}).AnyTimes()
+
+	draMgr := &DRAResourceSliceManager{
+		lookup: func(pool, device string) (string, *DRAMigDeviceInfo) {
+			if pool == "poolA" && device == "gpu-x" {
+				return parentUUID, &DRAMigDeviceInfo{
+					MIGDeviceUUID: migUUID,
+					Profile:       migProfile,
+					ParentUUID:    parentUUID,
+				}
+			}
+			return "", nil
+		},
+	}
+
+	pm := &PodMapper{
+		Config:               &appconfig.Config{NvidiaResourceNames: []string{appconfig.NvidiaResourceName}},
+		ResourceSliceManager: draMgr,
+	}
+
+	resp := &podresourcesapi.ListPodResourcesResponse{
+		PodResources: []*podresourcesapi.PodResources{{
+			Name:      "pod1",
+			Namespace: "ns1",
+			Containers: []*podresourcesapi.ContainerResources{{
+				Name: "ctr1",
+				DynamicResources: []*podresourcesapi.DynamicResource{{
+					ClaimName:      "claim1",
+					ClaimNamespace: "ns1",
+					ClaimResources: []*podresourcesapi.ClaimResource{{
+						DriverName: DRAGPUDriverName,
+						PoolName:   "poolA",
+						DeviceName: "gpu-x",
+					}},
+				}},
+			}},
+		}},
+	}
+
+	got := pm.toDeviceToPodsDRA(resp, mockDeviceInfo)
+
+	// Both keys must be present: the parent UUID (used by parent-GPU metrics)
+	// and the GPU-instance identifier (used by per-MIG metrics).
+	gpuInstanceKey := fmt.Sprintf("%d-%d", gpuIndex, gpuInstanceID)
+	require.Contains(t, got, parentUUID, "parent UUID key must be registered")
+	require.Contains(t, got, gpuInstanceKey, "GPU-instance key %q must be registered for MIG fan-out", gpuInstanceKey)
+	assert.Len(t, got, 2, "exactly two keys expected: parent UUID and GPU-instance identifier")
+
+	for _, key := range []string{parentUUID, gpuInstanceKey} {
+		pis := got[key]
+		require.Len(t, pis, 1, "key %q should resolve to one pod info", key)
+		assert.Equal(t, "pod1", pis[0].Name)
+		assert.Equal(t, "ns1", pis[0].Namespace)
+		assert.Equal(t, "ctr1", pis[0].Container)
+
+		dr := pis[0].DynamicResources
+		require.NotNil(t, dr, "DynamicResources must be set for key %q", key)
+		assert.Equal(t, "claim1", dr.ClaimName)
+		assert.Equal(t, DRAGPUDriverName, dr.DriverName)
+		require.NotNil(t, dr.MIGInfo, "MIGInfo must be set for key %q", key)
+		assert.Equal(t, migUUID, dr.MIGInfo.MIGDeviceUUID)
+		assert.Equal(t, migProfile, dr.MIGInfo.Profile)
+		assert.Equal(t, parentUUID, dr.MIGInfo.ParentUUID)
+	}
+}
+
+// draStaticPodResourcesServer returns a pre-built ListPodResourcesResponse
+// for a single test, used to drive PodMapper.Process end-to-end without
+// depending on JSON sample fixtures.
+type draStaticPodResourcesServer struct {
+	podresourcesapi.UnimplementedPodResourcesListerServer
+	response *podresourcesapi.ListPodResourcesResponse
+}
+
+func (s *draStaticPodResourcesServer) List(
+	_ context.Context, _ *podresourcesapi.ListPodResourcesRequest,
+) (*podresourcesapi.ListPodResourcesResponse, error) {
+	return s.response, nil
+}
+
+// TestProcessPodMapper_DRAEnrichmentForMIGClaim is the end-to-end counterpart
+// of TestPodDRAInfo_MIGAddsGPUInstanceMapping: it runs PodMapper.Process with
+// KubernetesEnableDRA=true and a per-MIG-instance DCGM metric whose
+// GetIDOfType resolves to "0-3", then asserts the enrichment loop attaches
+// pod, namespace, container, dra_*, and dra_mig_* attributes. This proves
+// that the GPU-instance mapping is not only created but actually consumed
+// during metric enrichment.
+func TestProcessPodMapper_DRAEnrichmentForMIGClaim(t *testing.T) {
+	testutils.RequireLinux(t)
+
+	const (
+		parentUUID    = "GPU-parent-uuid"
+		migUUID       = "MIG-12345"
+		migProfile    = "1g.12gb"
+		gpuInstanceID = 3
+		gpuIndex      = uint(0)
+		poolName      = "poolA"
+		deviceName    = "gpu-x"
+	)
+
+	tmpDir, cleanup := testutils.CreateTmpDir(t)
+	defer cleanup()
+	socketPath := tmpDir + "/kubelet.sock"
+
+	server := grpc.NewServer()
+	podresourcesapi.RegisterPodResourcesListerServer(server, &draStaticPodResourcesServer{
+		response: &podresourcesapi.ListPodResourcesResponse{
+			PodResources: []*podresourcesapi.PodResources{{
+				Name:      "pod1",
+				Namespace: "ns1",
+				Containers: []*podresourcesapi.ContainerResources{{
+					Name: "ctr1",
+					DynamicResources: []*podresourcesapi.DynamicResource{{
+						ClaimName:      "claim1",
+						ClaimNamespace: "ns1",
+						ClaimResources: []*podresourcesapi.ClaimResource{{
+							DriverName: DRAGPUDriverName,
+							PoolName:   poolName,
+							DeviceName: deviceName,
+						}},
+					}},
+				}},
+			}},
+		},
+	})
+	cleanupServer := testutils.StartMockServer(t, server, socketPath)
+	defer cleanupServer()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockNVML := mocknvmlprovider.NewMockNVML(ctrl)
+	mockNVML.EXPECT().GetMIGDeviceInfoByID(migUUID).Return(&nvmlprovider.MIGDeviceInfo{
+		ParentUUID:    parentUUID,
+		GPUInstanceID: gpuInstanceID,
+	}, nil).AnyTimes()
+	originalNVML := nvmlprovider.Client()
+	defer nvmlprovider.SetClient(originalNVML)
+	nvmlprovider.SetClient(mockNVML)
+
+	mockDeviceInfo := mockdeviceinfo.NewMockProvider(ctrl)
+	mockDeviceInfo.EXPECT().GPUCount().Return(toUint(1)).AnyTimes()
+	mockDeviceInfo.EXPECT().GPU(gpuIndex).Return(deviceinfo.GPUInfo{
+		DeviceInfo: dcgm.Device{UUID: parentUUID, GPU: gpuIndex},
+		MigEnabled: true,
+	}).AnyTimes()
+
+	// Construct PodMapper directly: NewPodMapper would try to build an
+	// in-cluster client and a real DRAResourceSliceManager, neither of which
+	// are available in unit tests. We inject a stub Lister-backed lookup.
+	pm := &PodMapper{
+		Config: &appconfig.Config{
+			KubernetesGPUIdType:       appconfig.GPUUID,
+			PodResourcesKubeletSocket: socketPath,
+			KubernetesEnableDRA:       true,
+		},
+		ResourceSliceManager: &DRAResourceSliceManager{
+			lookup: func(pool, device string) (string, *DRAMigDeviceInfo) {
+				if pool == poolName && device == deviceName {
+					return parentUUID, &DRAMigDeviceInfo{
+						MIGDeviceUUID: migUUID,
+						Profile:       migProfile,
+						ParentUUID:    parentUUID,
+					}
+				}
+				return "", nil
+			},
+		},
+	}
+
+	// Per-MIG-instance DCGM metric. GetIDOfType returns "<gpu>-<gpuInstanceID>"
+	// when MigProfile is non-empty, which is the key the DRA mapping registers
+	// for MIG claims.
+	counter := counters.Counter{
+		FieldID:   1001,
+		FieldName: "DCGM_FI_DEV_SM_CLOCK",
+		PromType:  "gauge",
+	}
+	metrics := collector.MetricsByCounter{
+		counter: []collector.Metric{{
+			GPU:           fmt.Sprint(gpuIndex),
+			GPUUUID:       parentUUID,
+			GPUInstanceID: fmt.Sprint(gpuInstanceID),
+			MigProfile:    "1g.10gb",
+			Value:         "1440",
+			Counter:       counter,
+			Attributes:    map[string]string{},
+			Labels:        map[string]string{},
+		}},
+	}
+
+	require.NoError(t, pm.Process(metrics, mockDeviceInfo))
+
+	require.Len(t, metrics[counter], 1, "metric should be enriched in place, not fanned out")
+	attrs := metrics[counter][0].Attributes
+
+	assert.Equal(t, "pod1", attrs[podAttribute])
+	assert.Equal(t, "ns1", attrs[namespaceAttribute])
+	assert.Equal(t, "ctr1", attrs[containerAttribute])
+	assert.Equal(t, "claim1", attrs[draClaimName])
+	assert.Equal(t, "ns1", attrs[draClaimNamespace])
+	assert.Equal(t, DRAGPUDriverName, attrs[draDriverName])
+	assert.Equal(t, poolName, attrs[draPoolName])
+	assert.Equal(t, deviceName, attrs[draDeviceName])
+	assert.Equal(t, migProfile, attrs[draMigProfile])
+	assert.Equal(t, migUUID, attrs[draMigDeviceUUID])
+}
+
 func TestProcessPodMapper_WithUID(t *testing.T) {
 	testutils.RequireLinux(t)
 

--- a/internal/pkg/transformation/types.go
+++ b/internal/pkg/transformation/types.go
@@ -78,11 +78,8 @@ type PodInfo struct {
 
 type DRAResourceSliceManager struct {
 	factory       informers.SharedInformerFactory
-	informer      cache.SharedIndexInformer
 	cancelContext context.CancelFunc
-	mu            sync.RWMutex
-	deviceToUUID  map[string]string            // pool/device -> UUID (for full GPUs)
-	migDevices    map[string]*DRAMigDeviceInfo // pool/device -> MIG info (for MIG devices)
+	lookup        deviceLookupFunc
 }
 
 // PodMetadata holds pod metadata from API server


### PR DESCRIPTION
This PR adds proper API discovery, refactors the DRA cache to use a Lister, and fixes MIG correctness gaps in pod-to-metric attribution for DRA.

Fixes https://github.com/NVIDIA/dcgm-exporter/issues/590. 

Tested both full GPU and MIG paths. Sharing test logs on A30 with MIG enabled. 

```
time=2026-06-02T19:42:06.979Z level=INFO msg="Initializing Pod Informer" nodeName=nim-operator-72q5r53
time=2026-06-02T19:42:07.068Z level=INFO msg="Using ResourceSlice API" groupVersion=resource.k8s.io/v1
time=2026-06-02T19:42:07.168Z level=INFO msg="Started DRAResourceSliceManager"

DCGM_FI_DEV_SM_CLOCK{gpu="0",UUID="GPU-f50641a9-38d7-6df1-0bec-e661b4ca1847",pci_bus_id="00000000:3B:00.0",device="nvidia0",modelName="NVIDIA A30",hostname="nim-operator-72q5r53"} 210

DCGM_FI_DEV_SM_CLOCK{gpu="1",UUID="GPU-e04ce2a0-21a4-b68c-854a-f5c0d26bfc0b",pci_bus_id="00000000:D8:00.0",device="nvidia1",modelName="NVIDIA A30",GPU_I_PROFILE="1g.6gb",GPU_I_ID="3",hostname="nim-operator-72q5r53",container="ctr0",dra_claim_name="pod-c98945f5d-dnjs6-mig-devices-thfdj",dra_claim_namespace="gpu-test4",dra_device_name="gpu-1-mig-1g6gb-14-0",dra_driver_name="gpu.nvidia.com",dra_mig_device_uuid="MIG-c73ab1c4-6cb7-59b6-be7e-21c4ac35c3b6",dra_mig_profile="1g.6gb",dra_pool_name="nim-operator-72q5r53",namespace="gpu-test4",pod="pod-c98945f5d-dnjs6"} 1440
DCGM_FI_DEV_SM_CLOCK{gpu="1",UUID="GPU-e04ce2a0-21a4-b68c-854a-f5c0d26bfc0b",pci_bus_id="00000000:D8:00.0",device="nvidia1",modelName="NVIDIA A30",GPU_I_PROFILE="1g.6gb",GPU_I_ID="3",hostname="nim-operator-72q5r53",container="ctr1",dra_claim_name="pod-c98945f5d-dnjs6-mig-devices-thfdj",dra_claim_namespace="gpu-test4",dra_device_name="gpu-1-mig-1g6gb-14-0",dra_driver_name="gpu.nvidia.com",dra_mig_device_uuid="MIG-c73ab1c4-6cb7-59b6-be7e-21c4ac35c3b6",dra_mig_profile="1g.6gb",dra_pool_name="nim-operator-72q5r53",namespace="gpu-test4",pod="pod-c98945f5d-dnjs6"} 1440
DCGM_FI_DEV_SM_CLOCK{gpu="1",UUID="GPU-e04ce2a0-21a4-b68c-854a-f5c0d26bfc0b",pci_bus_id="00000000:D8:00.0",device="nvidia1",modelName="NVIDIA A30",GPU_I_PROFILE="1g.6gb",GPU_I_ID="3",hostname="nim-operator-72q5r53",container="ctr2",dra_claim_name="pod-c98945f5d-dnjs6-mig-devices-thfdj",dra_claim_namespace="gpu-test4",dra_device_name="gpu-1-mig-1g6gb-14-0",dra_driver_name="gpu.nvidia.com",dra_mig_device_uuid="MIG-c73ab1c4-6cb7-59b6-be7e-21c4ac35c3b6",dra_mig_profile="1g.6gb",dra_pool_name="nim-operator-72q5r53",namespace="gpu-test4",pod="pod-c98945f5d-dnjs6"} 1440
DCGM_FI_DEV_SM_CLOCK{gpu="1",UUID="GPU-e04ce2a0-21a4-b68c-854a-f5c0d26bfc0b",pci_bus_id="00000000:D8:00.0",device="nvidia1",modelName="NVIDIA A30",GPU_I_PROFILE="1g.6gb",GPU_I_ID="3",hostname="nim-operator-72q5r53",container="ctr3",dra_claim_name="pod-c98945f5d-dnjs6-mig-devices-thfdj",dra_claim_namespace="gpu-test4",dra_device_name="gpu-1-mig-1g6gb-14-0",dra_driver_name="gpu.nvidia.com",dra_mig_device_uuid="MIG-c73ab1c4-6cb7-59b6-be7e-21c4ac35c3b6",dra_mig_profile="1g.6gb",dra_pool_name="nim-operator-72q5r53",namespace="gpu-test4",pod="pod-c98945f5d-dnjs6"} 1440
```
