### PR TITLE
feat(helm): make automountServiceAccountToken configurable

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -58,7 +58,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "dcgm-exporter.serviceAccountName" . }}
-      automountServiceAccountToken: {{ or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
+      automountServiceAccountToken: {{ ternary (or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled) .Values.serviceAccount.automountServiceAccountToken (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
       {{- if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/deployment/templates/serviceaccount.yaml
+++ b/deployment/templates/serviceaccount.yaml
@@ -24,5 +24,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled }}
+automountServiceAccountToken: {{ ternary (or (and (or .Values.kubernetes.enablePodLabels .Values.kubernetes.enablePodUID) .Values.kubernetes.rbac.create) .Values.kubernetesDRA.enabled) .Values.serviceAccount.automountServiceAccountToken (kindIs "invalid" .Values.serviceAccount.automountServiceAccountToken) }}
 {{- end -}}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -72,6 +72,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+  # Whether to mount the SA token on the DaemonSet pod and the ServiceAccount.
+  # If not set, derived from kubernetes.enablePodLabels/enablePodUID with rbac.create, or kubernetesDRA.enabled.
+  automountServiceAccountToken:
+
 rollingUpdate:
   # Specifies maximum number of DaemonSet pods that can be unavailable during the update
   maxUnavailable: 1


### PR DESCRIPTION
Resolves #624

- Adds `serviceAccount.automountServiceAccountToken` to expose the field as an explicit override.
- Backward compatible: when unset, falls back to the existing derivation from `kubernetes.enablePodLabels`/`enablePodUID` with `rbac.create`, or `kubernetesDRA.enabled`.
- Applied to both the DaemonSet pod spec and the ServiceAccount for consistency.
- Verified with `helm template` for default, explicit `true`, explicit `false`, and the DRA-enabled derivation path.