### PR TITLE
feat(metrics): enable RETIRED_SBE and RETIRED_DBE counters by default

### DIFF
--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -46,8 +46,8 @@ DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
 # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
 
 # Retired pages
-# DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
-# DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
 # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
 
 # NVLink

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -53,8 +53,8 @@ DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
 # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
 
 # Retired pages
-# DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
-# DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
 # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
 
 # NVLink

--- a/tests/integration/testdata/default-counters.csv
+++ b/tests/integration/testdata/default-counters.csv
@@ -46,8 +46,8 @@ DCGM_FI_DEV_FB_USED, gauge, Frame buffer memory used (in MB).
 # DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.
 
 # Retired pages
-# DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
-# DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
+DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
+DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
 # DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.
 
 # NVLink


### PR DESCRIPTION
Resolves #646

- Uncomments `DCGM_FI_DEV_RETIRED_SBE` and `DCGM_FI_DEV_RETIRED_DBE` in `etc/dcp-metrics-included.csv`, `etc/default-counters.csv`, and `tests/integration/testdata/default-counters.csv`.
- These are the standard ECC retired-page counters that fleet operators use to detect GPUs starting to fail. Available on all datacenter GPUs where ECC is enabled.
- Git history (`c6a7730b`, 2021-02-25) shows these lines were inherited as commented-out defaults rather than deliberately disabled. No Go code references them, so the generic CSV-loaded counter path is sufficient.
- `DCGM_FI_DEV_RETIRED_PENDING` (adjacent line) left commented -- not requested in the issue, avoiding scope creep.
- Note: the issue also mentions `DCGM_FI_DEV_XID_ERRORS` as missing, but that metric is already enabled by default in `default-counters.csv` and has dedicated handling in `internal/pkg/collector/xid_collector.go`. If a user isn't seeing it, that's likely environmental (custom counters file, version mismatch, or GPU/driver not reporting). Recommend a separate issue with version + hardware details to investigate.