### PR TITLE
feat(ci+docs): finish Go 1.26 upgrade -- align CI workflow and README

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.24
+        go-version: '1.26'
 
     - name: Build
       run: make binary

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ To enable GPU-to-job mapping on the DCGM-exporter side, users must run the DCGM-
 
 In order to build dcgm-exporter ensure you have the following:
 
-* [Golang >= 1.24 installed](https://go.dev/)
+* [Golang >= 1.26 installed](https://go.dev/)
 * [DCGM installed](https://developer.nvidia.com/dcgm)
 * Have Linux machine with GPU, compatible with DCGM.
 


### PR DESCRIPTION
Resolves #641

The bulk of the Go 1.26 upgrade landed in #656 (the 4.5.3-4.8.2 release commit), which bumped `go.mod` to `1.26.0` / `toolchain go1.26.2` along with the `Makefile` and Dockerfiles. The CI workflow and README minimum-version statement were missed in that PR.

- `.github/workflows/go.yml`: `go-version: 1.24` -> `'1.26'` so CI's installed Go matches what the toolchain directive actually pulls.
- `README.md`: `Golang >= 1.24` -> `Golang >= 1.26` so the prerequisites match `go.mod`.

This finishes the closing two stragglers from #641 so the stated Go version is consistent across `go.mod`, `Makefile`, Dockerfiles, CI, and README.