### PR TITLE
Fix inconsistencies in service toggle and TLS conditionals

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -79,7 +79,7 @@ spec:
       - name: "pod-gpu-resources"
         hostPath:
           path: {{ .Values.kubeletPath }}
-      {{- if and .Values.tlsServerConfig.enabled }}
+      {{- if .Values.tlsServerConfig.enabled }}
       - name: "tls"
         secret:
           secretName: {{ include "dcgm-exporter.tlsCertsSecretName" . }}
@@ -170,7 +170,7 @@ spec:
         - name: "pod-gpu-resources"
           readOnly: true
           mountPath: "/var/lib/kubelet/pod-resources"
-        {{- if and .Values.tlsServerConfig.enabled }}
+        {{- if .Values.tlsServerConfig.enabled }}
         - name: "tls"
           mountPath: /etc/dcgm-exporter/tls
         {{- end }}

--- a/deployment/templates/service.yaml
+++ b/deployment/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.service.enable }}
+{{- if .Values.service.enabled }}
 # Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -75,7 +75,7 @@ serviceAccount:
 rollingUpdate:
   # Specifies maximum number of DaemonSet pods that can be unavailable during the update
   maxUnavailable: 1
-  # Specifies maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during during an update
+  # Specifies maximum number of nodes with an existing available DaemonSet pod that can have an updated DaemonSet pod during an update
   maxSurge: 0
 
 # Labels to be added to dcgm-exporter pods
@@ -106,7 +106,7 @@ securityContext:
 # Defines the dcgm-exporter service
 service:
   # When enabled, the helm chart will create service
-  enable: true
+  enabled: true
   type: ClusterIP
   # Accepts either "Cluster" or "Local", choose Local if you want to route internal traffic within the node only
   internalTrafficPolicy: Cluster


### PR DESCRIPTION
This PR for fixing the chart

- Rename `service.enable` to `service.enabled` for consistency with other feature toggles in the chart.
All other feature toggles in the chart use `enabled` (e.g., `serviceMonitor.enabled`, `debugDump.enabled`, `tlsServerConfig.enabled`, `kubernetesDRA.enabled`). Using `enable` for the service is inconsistent and can cause confusion for users expecting the same naming pattern. This change aligns it with the rest of the chart.

- Remove redundant `and` operator from `TLS` conditionals in `daemonset.yaml`.
Uses the `and` operator with only one operand, which is redundant, `and` is meant to combine multiple conditions.