### PR TITLE
packaging/systemd: log to journald instead of an unrotated logfile

### DIFF
--- a/packaging/config-files/systemd/nvidia-dcgm-exporter.service
+++ b/packaging/config-files/systemd/nvidia-dcgm-exporter.service
@@ -22,9 +22,6 @@ After=nvidia-dcgm.service
 User=root
 PrivateTmp=false
 
-StandardOutput=append:/var/log/dcgm-exporter.log
-StandardError=append:/var/log/dcgm-exporter.log
-
 ExecStart=/usr/bin/dcgm-exporter -f /etc/dcgm-exporter/default-counters.csv
 
 Restart=on-abort


### PR DESCRIPTION
Closes #668.

Removes the `StandardOutput`/`StandardError` `append:` directives from the systemd unit so the exporter inherits systemd's default `journal` sink. Output is then queryable via `journalctl -u nvidia-dcgm-exporter`, rotated/size-capped by journald, and structured with unit/PID/priority, instead of writing to an unrotated `/var/log/dcgm-exporter.log` that operators must manage separately. This matches the change requested in the issue.