### PR TITLE
grafana: show Hostname in dashboard legends for multi-node clusters

### DIFF
--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -93,7 +93,7 @@
           "expr": "DCGM_FI_DEV_GPU_TEMP{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "instant": false,
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -245,7 +245,7 @@
         {
           "expr": "DCGM_FI_DEV_POWER_USAGE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -405,7 +405,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -496,7 +496,7 @@
         {
           "expr": "DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -586,7 +586,7 @@
         {
           "expr": "DCGM_FI_DEV_FB_USED{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -676,7 +676,7 @@
         {
           "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{Hostname}} GPU {{gpu}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Closes #630.

In a multi-node cluster the bundled dashboard's per-GPU legends collide: every node shows `GPU 0`, `GPU 1`, ... with no way to tell them apart (see the screenshot in the issue). This prepends the `Hostname` label so each series reads `<hostname> GPU <n>`.

Only the 6 per-GPU panels are changed; the cluster-wide avg/sum panels (empty legend) are left as-is.

Format is open to preference -- happy to use `{{instance}}` instead of `{{Hostname}}`, or a different separator, if the maintainers prefer.