### PR TITLE
grafana: add Kubernetes inference observability dashboards (cost attribution, KEDA autoscaling, disaggregated inference)

### DIFF
--- a/grafana/dynamo-disaggregated-inference.json
+++ b/grafana/dynamo-disaggregated-inference.json
@@ -1,0 +1,196 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Dynamo Disaggregated Serving \u2014 Prefill vs Decode Analysis",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Prefill Worker GPU Utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{pod=~\".*prefill.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "title": "Decode Worker GPU Utilization",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_PROF_GR_ENGINE_ACTIVE{pod=~\".*decode.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "title": "Tensor Core Activity (Prefill vs Decode)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      }
+    },
+    {
+      "title": "Memory Bandwidth (DRAM Active) \u2014 Decode Should Be Higher",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_PROF_DRAM_ACTIVE{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit"
+        }
+      }
+    },
+    {
+      "title": "GPU Memory Used (FB Used MiB)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_DEV_FB_USED{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decmbytes"
+        }
+      }
+    },
+    {
+      "title": "PCIe Throughput (KV Transfer via TCP)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_PROF_PCIE_TX_BYTES{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "TX: {{pod}}"
+        },
+        {
+          "expr": "DCGM_FI_PROF_PCIE_RX_BYTES{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "RX: {{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0
+      }
+    ]
+  },
+  "tags": [
+    "gpu",
+    "dynamo",
+    "disaggregated"
+  ],
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "title": "Dynamo Disaggregated \u2014 Prefill vs Decode",
+  "uid": null,
+  "id": null
+}

--- a/grafana/gpu-cost-attribution.json
+++ b/grafana/gpu-cost-attribution.json
@@ -1,0 +1,220 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "GPU Cost Attribution \u2014 Per DGD (Dynamo + vLLM)",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "GPU Cost per Hour by DGD",
+      "type": "table",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "deployment:gpu_cost_per_hour:sum",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{dgd}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        },
+        "overrides": []
+      }
+    },
+    {
+      "title": "GPU Waste % by DGD",
+      "type": "gauge",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "deployment:gpu_waste_fraction:ratio * 100",
+          "legendFormat": "{{dgd}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "min": 0,
+          "max": 100,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 60
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "title": "GPU Utilization Over Time (per pod)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "pod:gpu_utilization:avg5m",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "title": "Allocated vs Effective Cost",
+      "type": "barchart",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "deployment:gpu_cost_per_hour:sum",
+          "legendFormat": "Allocated: {{dgd}}"
+        },
+        {
+          "expr": "deployment:gpu_effective_cost_per_hour:sum",
+          "legendFormat": "Effective: {{dgd}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD"
+        }
+      }
+    },
+    {
+      "title": "GPU Price per Hour (from AWS Price List API)",
+      "type": "stat",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "gpu_price_per_hour",
+          "legendFormat": "{{instance_type}} ({{gpu_model}})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      }
+    },
+    {
+      "title": "DCGM Power Draw by Pod",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "DCGM_FI_DEV_POWER_USAGE{pod!=\"\",namespace=\"dynamo-system\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "watt"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "gpu",
+    "cost",
+    "dynamo"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "title": "GPU Cost Attribution \u2014 Per DGD",
+  "uid": null
+}

--- a/grafana/keda-gpu-scaling.json
+++ b/grafana/keda-gpu-scaling.json
@@ -1,0 +1,275 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "KEDA Autoscaling \u2014 Prefill vs Decode Scaling Behavior",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Prefill Replicas (KEDA Scaled)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "kube_deployment_spec_replicas{deployment=~\".*prefill.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "desired replicas"
+        },
+        {
+          "expr": "kube_deployment_status_replicas_available{deployment=~\".*prefill.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "available replicas"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "title": "Decode Replicas (KEDA Scaled)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "kube_deployment_spec_replicas{deployment=~\".*decode.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "desired replicas"
+        },
+        {
+          "expr": "kube_deployment_status_replicas_available{deployment=~\".*decode.*\",namespace=\"dynamo-system\"}",
+          "legendFormat": "available replicas"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0,
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "title": "Prefill Scaling Signal \u2014 GPU Utilization (threshold: 70%)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(DCGM_FI_PROF_GR_ENGINE_ACTIVE{pod=~\".*prefill.*\",namespace=\"dynamo-system\"})",
+          "legendFormat": "total prefill GPU util"
+        },
+        {
+          "expr": "0.7",
+          "legendFormat": "scale-up threshold"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "title": "Decode Scaling Signal \u2014 GPU Memory Pressure (threshold: 80%)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "avg(DCGM_FI_DEV_FB_USED{pod=~\".*decode.*\",namespace=\"dynamo-system\"} / (DCGM_FI_DEV_FB_USED{pod=~\".*decode.*\",namespace=\"dynamo-system\"} + DCGM_FI_DEV_FB_FREE{pod=~\".*decode.*\",namespace=\"dynamo-system\"}))",
+          "legendFormat": "decode memory usage %"
+        },
+        {
+          "expr": "0.8",
+          "legendFormat": "scale-up threshold"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      }
+    },
+    {
+      "title": "Total GPU Capacity (cluster)",
+      "type": "stat",
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "sum(kube_node_status_capacity{resource=~\"nvidia_com.*\",resource!=\"nvidia_com_gpu\"}) OR sum(kube_node_status_capacity{resource=\"nvidia_com_gpu\"})",
+          "legendFormat": "total GPU/MIG slices"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "title": "GPU Allocatable per Node",
+      "type": "table",
+      "gridPos": {
+        "h": 6,
+        "w": 16,
+        "x": 8,
+        "y": 16
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "kube_node_status_allocatable{resource=~\"nvidia_com.*\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "{{node}} \u2014 {{resource}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "title": "KEDA Scaler Metrics (raw values driving scaling decisions)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaler_metrics_value{scaledObject=~\"prefill.*\"}",
+          "legendFormat": "prefill scaler value"
+        },
+        {
+          "expr": "keda_metrics_adapter_scaler_metrics_value{scaledObject=~\"decode.*\"}",
+          "legendFormat": "decode scaler value"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "title": "Scale Events Timeline",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "targets": [
+        {
+          "expr": "changes(kube_deployment_spec_replicas{deployment=~\".*prefill.*\",namespace=\"dynamo-system\"}[5m])",
+          "legendFormat": "prefill scale events (5m)"
+        },
+        {
+          "expr": "changes(kube_deployment_spec_replicas{deployment=~\".*decode.*\",namespace=\"dynamo-system\"}[5m])",
+          "legendFormat": "decode scale events (5m)"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "min": 0
+        }
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "DS_PROMETHEUS",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0
+      }
+    ]
+  },
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "tags": [
+    "gpu",
+    "keda",
+    "scaling",
+    "mig"
+  ],
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "title": "KEDA GPU Autoscaling \u2014 Prefill vs Decode",
+  "uid": null,
+  "id": null
+}


### PR DESCRIPTION
## Summary

Adds three Grafana dashboards for Kubernetes-based LLM inference observability,
covering gaps not addressed by the existing `dcgm-exporter-dashboard.json`.

### Dashboards added

**`gpu-cost-attribution.json`**
Per-deployment GPU cost attribution using DCGM power metrics + AWS Price List API.
Panels: cost/hr by deployment, GPU waste %, utilization over time, allocated vs effective cost, DCGM power draw per pod.

**`keda-gpu-scaling.json`**
KEDA autoscaling signals for disaggregated inference (prefill vs decode workers).
Panels: prefill replicas (SM utilization signal, 70% threshold), decode replicas (HBM pressure signal, 80% threshold), raw scaler metrics, scale events timeline.

**`dynamo-disaggregated-inference.json`**
GPU hardware breakdown for prefill vs decode worker types.
Panels: SM utilization per worker type, tensor core activity, memory bandwidth (DRAM active), HBM used, PCIe throughput (KV transfer).

### Reference implementation
Full deployment stack (EKS + NVIDIA GPU Operator + DCGM + KEDA + Prometheus):
https://github.com/sguruvar/ai-inference-observability-eks

All dashboards use `${DS_PROMETHEUS}` as the datasource variable and have `uid: null` for portable import.