### PR TITLE
deployment: add configurable NetworkPolicy template

### DIFF
--- a/deployment/Chart.yaml
+++ b/deployment/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: dcgm-exporter
 description: A Helm chart for DCGM exporter
-version: "4.8.2"
+version: "4.8.3"
 kubeVersion: ">= 1.19.0-0"
-appVersion: "4.8.2"
+appVersion: "4.8.3"
 sources:
 - https://github.com/nvidia/dcgm-exporter
 home: https://github.com/nvidia/dcgm-exporter/

--- a/deployment/templates/networkpolicy.yaml
+++ b/deployment/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "dcgm-exporter.fullname" . }}
+  namespace: {{ include "dcgm-exporter.namespace" . }}
+  labels:
+    {{- include "dcgm-exporter.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "dcgm-exporter.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - {{- if eq (len .Values.networkPolicy.ingress.from) 0 }}
+      from: []
+      {{- else }}
+      from:
+        {{- toYaml .Values.networkPolicy.ingress.from | nindent 8 }}
+      {{- end }}
+      {{- if eq (len .Values.networkPolicy.ingress.ports) 0 }}
+      ports: []
+      {{- else }}
+      ports:
+        {{- toYaml .Values.networkPolicy.ingress.ports | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -351,3 +351,11 @@ livenessProbe:
 
 readinessProbe:
   initialDelaySeconds: 45
+
+networkPolicy:
+  enabled: false
+  ingress:
+    from: []
+    ports:
+      - port: 9400
+        protocol: TCP


### PR DESCRIPTION
add configurable NetworkPolicy template. Useful for when whitelisting metrics port is needed.

ref: https://github.com/NVIDIA/gpu-operator/pull/2540
