### PR TITLE
build: add --provenance=false to fix OCI manifest format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ VERSION        := $(NEW_EXPORTER_VERSION)
 FULL_VERSION   := $(DCGM_VERSION)-$(VERSION)
 OUTPUT         := type=oci,dest=/dev/null
 PLATFORMS      := linux/amd64,linux/arm64
-DOCKERCMD      := docker --debug buildx build
+DOCKERCMD      := docker --debug buildx build --provenance=false
 MODULE         := github.com/NVIDIA/dcgm-exporter
 CONTAINER      ?= all
 


### PR DESCRIPTION
Closes #676

## Problem

`docker buildx build` with BuildKit >=0.11 attaches provenance attestations by default. This causes the published image to be an **OCI image index** (`application/vnd.oci.image.index.v1+json`) instead of a **Docker manifest list** (`application/vnd.docker.distribution.manifest.list.v2+json`).

Consumers that rely on the Docker registry v2 manifest API break:
- **Renovate** fails to parse the manifest and cannot detect new image versions
- **Harbor** and internal registries in air-gapped HPC environments reject or mis-classify the image
- `docker pull` on older Docker Engine versions may fail

## Fix

Add `--provenance=false` to `DOCKERCMD`. This suppresses provenance attestation attachment and keeps the published manifest as a standard Docker v2 manifest list.

The `local` build target overrides `DOCKERCMD` entirely (to plain `docker build`) and is unaffected.

## Precedent

NVIDIA/gpu-operator#2540 applied the identical fix.

## Testing

```bash
# After the fix, verify the manifest type:
docker buildx imagetools inspect nvidia/dcgm-exporter:latest
# Should show: application/vnd.docker.distribution.manifest.list.v2+json
```