### PR TITLE
helm: allow overriding probe timeoutSeconds/failureThreshold

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -198,6 +198,12 @@ spec:
           {{- end }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          {{- with .Values.livenessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ . }}
+          {{- end }}
+          {{- with .Values.livenessProbe.failureThreshold }}
+          failureThreshold: {{ . }}
+          {{- end }}
         readinessProbe:
           {{- if not $.Values.basicAuth.users }}
           httpGet:
@@ -209,6 +215,15 @@ spec:
               port: {{ .Values.service.port }}
           {{- end }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          {{- with .Values.readinessProbe.periodSeconds }}
+          periodSeconds: {{ . }}
+          {{- end }}
+          {{- with .Values.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ . }}
+          {{- end }}
+          {{- with .Values.readinessProbe.failureThreshold }}
+          failureThreshold: {{ . }}
+          {{- end }}
         {{- if .Values.resources }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -348,6 +348,16 @@ kubernetesDRA:
 livenessProbe:
   initialDelaySeconds: 45
   periodSeconds: 5
+  # When unset, the kubelet defaults apply (timeoutSeconds: 1, failureThreshold: 3).
+  # On busy nodes the /health endpoint can take longer than 1s to respond, so raise
+  # these to avoid the kubelet false-killing a healthy container.
+  # timeoutSeconds: 5
+  # failureThreshold: 5
 
 readinessProbe:
   initialDelaySeconds: 45
+  # When unset, the kubelet defaults apply (periodSeconds: 10, timeoutSeconds: 1,
+  # failureThreshold: 3).
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 3


### PR DESCRIPTION
## What

Expose `timeoutSeconds` and `failureThreshold` (plus `readinessProbe.periodSeconds`)
as optional values on the liveness and readiness probes in the DaemonSet chart.

## Why

The chart currently only templatizes `initialDelaySeconds` and (for liveness)
`periodSeconds`. It never sets `timeoutSeconds` or `failureThreshold`, so the
kubelet defaults apply: `timeoutSeconds: 1`, `failureThreshold: 3`.

The liveness probe hits `/health` over HTTP. On busy nodes that endpoint can take
longer than 1s to respond; three consecutive >1s responses trip the default
`failureThreshold: 3` and the kubelet kills an otherwise-healthy container
(graceful exit 0, not OOM), which then restarts and can repeat — a false-kill /
crashloop. Today there is no values-based way to loosen the probe; the only
options are vendoring the chart or post-rendering the manifest.

This adds the missing knobs so operators can set e.g. `timeoutSeconds: 5` /
`failureThreshold: 5` (see #612 for a report of the same symptom).

## How

The new fields are rendered with `{{- with ... }}`, so when they are unset the
template emits nothing and the kubelet defaults continue to apply. **Existing
installations see no change** unless they explicitly set the new values.

## Validation

- `helm template` with no overrides: rendered probes are byte-for-byte unchanged
  (no `timeoutSeconds` / `failureThreshold` emitted).
- `helm template` with the new values set: fields render correctly on both the
  `httpGet` and `basicAuth` `tcpSocket` probe branches.
- `helm lint`: passes.
