### PR TITLE
Prefer NVML MIG profile names

### DIFF
--- a/internal/mocks/pkg/nvmlprovider/mock_client.go
+++ b/internal/mocks/pkg/nvmlprovider/mock_client.go
@@ -111,6 +111,21 @@ func (mr *MockNVMLMockRecorder) GetDeviceProcessUtilization(gpuUUID any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeviceProcessUtilization", reflect.TypeOf((*MockNVML)(nil).GetDeviceProcessUtilization), gpuUUID)
 }
 
+// GetGPUInstanceProfileName mocks base method.
+func (m *MockNVML) GetGPUInstanceProfileName(parentGPUUUID string, profileID uint) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGPUInstanceProfileName", parentGPUUUID, profileID)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGPUInstanceProfileName indicates an expected call of GetGPUInstanceProfileName.
+func (mr *MockNVMLMockRecorder) GetGPUInstanceProfileName(parentGPUUUID, profileID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGPUInstanceProfileName", reflect.TypeOf((*MockNVML)(nil).GetGPUInstanceProfileName), parentGPUUUID, profileID)
+}
+
 // GetMIGDeviceInfoByID mocks base method.
 func (m *MockNVML) GetMIGDeviceInfoByID(arg0 string) (*nvmlprovider.MIGDeviceInfo, error) {
 	m.ctrl.T.Helper()

--- a/internal/pkg/deviceinfo/device_info.go
+++ b/internal/pkg/deviceinfo/device_info.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
 )
 
 const deviceInitMessage = "System entities of type %s initialized"
@@ -314,17 +315,37 @@ func (s *Info) initializeNvSwitchInfo(sOpt appconfig.DeviceOptions) error {
 	return err
 }
 
-func (s *Info) setGPUInstanceProfileName(entityID uint, profileName string) bool {
+func (s *Info) setGPUInstanceProfileName(entityID uint, dcgmProfileName string) bool {
 	for i := uint(0); i < s.gpuCount; i++ {
 		for j := range s.gpus[i].GPUInstances {
 			if s.gpus[i].GPUInstances[j].EntityId == entityID {
-				s.gpus[i].GPUInstances[j].ProfileName = profileName
+				s.gpus[i].GPUInstances[j].ProfileName = s.getGPUInstanceProfileName(
+					s.gpus[i], s.gpus[i].GPUInstances[j], dcgmProfileName)
 				return true
 			}
 		}
 	}
 
 	return false
+}
+
+func (s *Info) getGPUInstanceProfileName(gpu GPUInfo, instance GPUInstanceInfo, dcgmProfileName string) string {
+	parentGPUUUID := instance.Info.GpuUuid
+	if parentGPUUUID == "" {
+		parentGPUUUID = gpu.DeviceInfo.UUID
+	}
+
+	nvmlProfileName, err := nvmlprovider.Client().GetGPUInstanceProfileName(parentGPUUUID, instance.Info.NvmlMigProfileId)
+	if err != nil {
+		slog.Debug("Falling back to DCGM MIG profile name", "entityID", instance.EntityId, "error", err)
+		return dcgmProfileName
+	}
+	if nvmlProfileName == "" {
+		slog.Debug("Falling back to DCGM MIG profile name", "entityID", instance.EntityId, "error", "NVML profile name is empty")
+		return dcgmProfileName
+	}
+
+	return nvmlProfileName
 }
 
 func (s *Info) setMigProfileNames(values []dcgm.FieldValue_v2) error {

--- a/internal/pkg/deviceinfo/device_info_test.go
+++ b/internal/pkg/deviceinfo/device_info_test.go
@@ -27,8 +27,10 @@ import (
 	"go.uber.org/mock/gomock"
 
 	mockdcgm "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/dcgmprovider"
+	mocknvml "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/nvmlprovider"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
 )
 
 var fakeProfileName = "2fake.4gb"
@@ -2610,6 +2612,89 @@ func TestSetMigProfileNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSetMigProfileNamesPrefersNVMLProfileName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDCGMProvider := mockdcgm.NewMockDCGM(ctrl)
+	mockNVMLProvider := mocknvml.NewMockNVML(ctrl)
+
+	realDCGM := dcgmprovider.Client()
+	realNVML := nvmlprovider.Client()
+	defer func() {
+		dcgmprovider.SetClient(realDCGM)
+		nvmlprovider.SetClient(realNVML)
+	}()
+
+	dcgmprovider.SetClient(mockDCGMProvider)
+	nvmlprovider.SetClient(mockNVMLProvider)
+
+	fieldValue := dcgm.FieldValue_v2{EntityID: 1}
+	deviceInfo := Info{
+		gpuCount: 1,
+		gpus: [dcgm.MAX_NUM_DEVICES]GPUInfo{
+			{
+				DeviceInfo: dcgm.Device{UUID: "GPU-parent"},
+				GPUInstances: []GPUInstanceInfo{
+					{
+						EntityId: 1,
+						Info: dcgm.MigEntityInfo{
+							GpuUuid:          "GPU-parent",
+							NvmlMigProfileId: 9,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockDCGMProvider.EXPECT().Fv2_String(fieldValue).Return("7g.79gb")
+	mockNVMLProvider.EXPECT().GetGPUInstanceProfileName("GPU-parent", uint(9)).Return("7g.80gb", nil)
+
+	err := deviceInfo.setMigProfileNames([]dcgm.FieldValue_v2{fieldValue})
+	require.NoError(t, err)
+	assert.Equal(t, "7g.80gb", deviceInfo.gpus[0].GPUInstances[0].ProfileName)
+}
+
+func TestSetMigProfileNamesFallsBackToDCGMProfileName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDCGMProvider := mockdcgm.NewMockDCGM(ctrl)
+	mockNVMLProvider := mocknvml.NewMockNVML(ctrl)
+
+	realDCGM := dcgmprovider.Client()
+	realNVML := nvmlprovider.Client()
+	defer func() {
+		dcgmprovider.SetClient(realDCGM)
+		nvmlprovider.SetClient(realNVML)
+	}()
+
+	dcgmprovider.SetClient(mockDCGMProvider)
+	nvmlprovider.SetClient(mockNVMLProvider)
+
+	fieldValue := dcgm.FieldValue_v2{EntityID: 1}
+	deviceInfo := Info{
+		gpuCount: 1,
+		gpus: [dcgm.MAX_NUM_DEVICES]GPUInfo{
+			{
+				DeviceInfo: dcgm.Device{UUID: "GPU-parent"},
+				GPUInstances: []GPUInstanceInfo{
+					{
+						EntityId: 1,
+						Info: dcgm.MigEntityInfo{
+							NvmlMigProfileId: 9,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	mockDCGMProvider.EXPECT().Fv2_String(fieldValue).Return("7g.79gb")
+	mockNVMLProvider.EXPECT().GetGPUInstanceProfileName("GPU-parent", uint(9)).Return("", fmt.Errorf("nvml unavailable"))
+
+	err := deviceInfo.setMigProfileNames([]dcgm.FieldValue_v2{fieldValue})
+	require.NoError(t, err)
+	assert.Equal(t, "7g.79gb", deviceInfo.gpus[0].GPUInstances[0].ProfileName)
 }
 
 func Test_getCoreArray(t *testing.T) {

--- a/internal/pkg/nvmlprovider/provider.go
+++ b/internal/pkg/nvmlprovider/provider.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"strconv"
 	"strings"
 
@@ -107,6 +108,48 @@ func (n nvmlProvider) GetMIGDeviceInfoByID(uuid string) (*MIGDeviceInfo, error) 
 	}
 
 	return getMIGDeviceInfoForOldDriver(uuid)
+}
+
+// GetGPUInstanceProfileName returns the canonical NVML name for a MIG GPU instance profile.
+func (n nvmlProvider) GetGPUInstanceProfileName(parentGPUUUID string, profileID uint) (string, error) {
+	if err := n.preCheck(); err != nil {
+		return "", fmt.Errorf("failed to get GPU instance profile name: %w", err)
+	}
+
+	device, ret := nvml.DeviceGetHandleByUUID(parentGPUUUID)
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to get parent device handle for UUID %s: %s", parentGPUUUID, nvml.ErrorString(ret))
+	}
+
+	if profileID > uint(math.MaxInt) {
+		return "", fmt.Errorf("GPU instance profile ID %d exceeds maximum int value %d", profileID, math.MaxInt)
+	}
+
+	profileIDInt := int(profileID)
+	infoV2, ret := device.GetGpuInstanceProfileInfoByIdV(profileIDInt).V2()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to get GPU instance profile info for UUID %s profile %d: %s",
+			parentGPUUUID, profileID, nvml.ErrorString(ret))
+	}
+
+	return migProfileNameFromBytes(infoV2.Name[:])
+}
+
+func migProfileNameFromBytes[T ~int8 | ~uint8](name []T) (string, error) {
+	var builder strings.Builder
+	for _, b := range name {
+		if b == 0 {
+			break
+		}
+		builder.WriteByte(byte(b))
+	}
+
+	profileName := builder.String()
+	if profileName == "" {
+		return "", errors.New("GPU instance profile name is empty")
+	}
+
+	return profileName, nil
 }
 
 // getMIGDeviceInfoForNewDriver identifies MIG Device Information for drivers >= R470 (470.42.01+),

--- a/internal/pkg/nvmlprovider/provider_test.go
+++ b/internal/pkg/nvmlprovider/provider_test.go
@@ -17,6 +17,7 @@
 package nvmlprovider
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,6 +54,32 @@ func TestGetAllMIGDevicesProcessMemory_When_NVML_Not_Initialized(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "failed to get MIG device process memory")
+}
+
+func TestGetGPUInstanceProfileName_When_NVML_Not_Initialized(t *testing.T) {
+	provider := nvmlProvider{}
+	result, err := provider.GetGPUInstanceProfileName("GPU-test-uuid", 9)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "failed to get GPU instance profile name")
+}
+
+func TestMigProfileNameFromBytes(t *testing.T) {
+	profileName, err := migProfileNameFromBytes([]int8{'7', 'g', '.', '8', '0', 'g', 'b', 0, 'x'})
+	require.NoError(t, err)
+	assert.Equal(t, "7g.80gb", profileName)
+
+	profileName, err = migProfileNameFromBytes([]int8{0})
+	assert.Error(t, err)
+	assert.Empty(t, profileName)
+}
+
+func TestGetGPUInstanceProfileName_When_ProfileID_Exceeds_MaxInt(t *testing.T) {
+	provider := nvmlProvider{initialized: true}
+	result, err := provider.GetGPUInstanceProfileName("GPU-test-uuid", uint(math.MaxInt)+1)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	assert.Contains(t, err.Error(), "exceeds maximum int value")
 }
 
 func TestGetMIGDeviceInfoByID_When_DriverVersion_Below_R470(t *testing.T) {

--- a/internal/pkg/nvmlprovider/types.go
+++ b/internal/pkg/nvmlprovider/types.go
@@ -20,6 +20,7 @@ package nvmlprovider
 
 type NVML interface {
 	GetMIGDeviceInfoByID(string) (*MIGDeviceInfo, error)
+	GetGPUInstanceProfileName(parentGPUUUID string, profileID uint) (string, error)
 	// GetDeviceProcessMemory returns memory usage for processes running on the GPU.
 	// Returns a map from PID to memory used in bytes.
 	GetDeviceProcessMemory(gpuUUID string) (map[uint32]uint64, error)


### PR DESCRIPTION
## Summary
- Prefer canonical NVML MIG GPU instance profile names when available.
- Fall back to the existing DCGM profile name if NVML lookup fails.
- Add coverage for the 7g.79gb to 7g.80gb correction path.

Related issue: https://github.com/NVIDIA/gpu-operator/issues/687

## Tests
- CGO_ENABLED=1 go test ./internal/pkg/deviceinfo ./internal/pkg/nvmlprovider
- CGO_ENABLED=1 go test ./internal/pkg/deviceinfo ./internal/pkg/nvmlprovider ./internal/pkg/transformation ./internal/pkg/watcher