### PR TITLE
collector: bound NVLink state cast (gosec G115)

### DIFF
--- a/internal/pkg/collector/p2p_status_collector.go
+++ b/internal/pkg/collector/p2p_status_collector.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math"
 	"slices"
 	"strconv"
 
@@ -33,6 +34,17 @@ import (
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/devicemonitoring"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/devicewatchlistmanager"
 )
+
+// boundedLinkValue returns the link value as int, or (_, false) if the
+// value exceeds math.MaxInt32. dcgm.Link_State is a small enum in
+// practice; the guard protects against future SDK changes that could
+// silently produce garbage metric values.
+func boundedLinkValue(link uint64) (int, bool) {
+	if link > math.MaxInt32 {
+		return 0, false
+	}
+	return int(link), true
+}
 
 // IsDCGMExpP2PStatusEnabled checks if the DCGM_EXP_P2P_STATUS counter exists
 func IsDCGMExpP2PStatusEnabled(counterList counters.CounterList) bool {
@@ -81,8 +93,12 @@ func (c *p2pStatusCollector) GetMetrics() (MetricsByCounter, error) {
 			metricValueLabels := maps.Clone(labels)
 			metricValueLabels[PeerGPULabel] = strconv.Itoa(j)
 			metricValueLabels[LinkStatusLabel] = p2pStatusToString(uint64(link))
-			// Safe conversion from link to int, assuming link values are small
-			linkValue := int(uint64(link)) //nolint:gosec // link values are small in practice
+			linkValue, ok := boundedLinkValue(uint64(link))
+			if !ok {
+				slog.Warn("unexpected NVLink state value; skipping metric",
+					slog.Uint64("value", uint64(link)))
+				continue
+			}
 			m := c.createMetric(metricValueLabels, monitoringInfo[i], uuid, linkValue)
 			metrics[c.counter] = append(metrics[c.counter], m)
 		}

--- a/internal/pkg/collector/p2p_status_collector_test.go
+++ b/internal/pkg/collector/p2p_status_collector_test.go
@@ -18,6 +18,7 @@ package collector
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
@@ -34,6 +35,32 @@ import (
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/devicewatchlistmanager"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/testutils"
 )
+
+func TestBoundedLinkValue(t *testing.T) {
+	cases := []struct {
+		name string
+		link uint64
+		want int
+		ok   bool
+	}{
+		{"positive: zero", 0, 0, true},
+		{"positive: small enum value", 6, 6, true},
+		{"boundary: MaxInt32", math.MaxInt32, math.MaxInt32, true},
+		{"corner: MaxInt32+1", math.MaxInt32 + 1, 0, false},
+		{"negative: MaxUint64", math.MaxUint64, 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := boundedLinkValue(tc.link)
+			if ok != tc.ok {
+				t.Fatalf("ok=%v want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Fatalf("got=%d want %d", got, tc.want)
+			}
+		})
+	}
+}
 
 func TestIsDCGMExpP2PStatusEnabled(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
What: bounds-check the NVLink state cast in p2p_status_collector.
Why: prevent silent truncation if a future DCGM SDK widens `dcgm.Link_State` (today a small enum, but stored in a `uint`).
How: skip the metric and warn when `uint64(link) > math.MaxInt32`.

Tested by: `TestBoundedLinkValue` (table-driven: zero, small enum, MaxInt32 boundary, MaxInt32+1 corner, MaxUint64 negative).

Found by: gosec 2.27.0 (Go security analyzer), rule **G115** — *CWE-190 integer overflow conversion uint64 → int*.