### PR TITLE
debug: dir mode 0o755 → 0o750 (gosec G301)

### DIFF
--- a/internal/pkg/debug/debug.go
+++ b/internal/pkg/debug/debug.go
@@ -67,7 +67,7 @@ func (fd *FileDumper) DumpToFile(data any, prefix, suffix string) (string, error
 	fullPath := filepath.Join(fd.config.Directory, filename)
 
 	// Ensure directory exists
-	if err := os.MkdirAll(fd.config.Directory, 0o755); err != nil {
+	if err := os.MkdirAll(fd.config.Directory, 0o750); err != nil {
 		return "", fmt.Errorf("failed to create debug directory: %w", err)
 	}
 


### PR DESCRIPTION
What: tighten debug-dump directory permissions.
Why: dumps may contain process IDs and GPU topology; world-read is unnecessary.
How: `0o755` → `0o750` on `MkdirAll` in `internal/pkg/debug/debug.go:70`.

Found by: gosec 2.27.0, rule **G301** — *CWE-276 expect directory permissions to be 0750 or less*.

Note: `MkdirAll` does not tighten permissions on a directory that already exists. If the dump directory was created earlier with looser perms (e.g. by a previous version of the binary), this change does not retroactively fix it.