### PR TITLE
docker: SHELL with pipefail (hadolint DL4006)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,10 @@
 FROM nvcr.io/nvidia/cuda:13.2.1-base-ubuntu22.04
+
+# Fail on errors in piped RUN commands (hadolint DL4006).
+# /bin/bash is a symlink to /usr/bin/bash on usrmerged Debian/Ubuntu;
+# we use /bin/bash here so hadolint recognises the pipefail SHELL.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG GOLANG_VERSION=1.26.2
 ARG USERNAME=developer
 ARG USER_UID=1000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,11 @@ ARG BASEIMAGE=nvcr.io/nvidia/cuda:13.2.1-base-ubuntu22.04
 #####
 FROM --platform=$BUILDPLATFORM ubuntu:22.04 AS builder
 
+# Fail on errors in piped RUN commands (hadolint DL4006).
+# /bin/bash is a symlink to /usr/bin/bash on usrmerged Debian/Ubuntu;
+# we use /bin/bash here so hadolint recognises the pipefail SHELL.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG GOLANG_VERSION=1.26.2
 
 WORKDIR /go/src/github.com/NVIDIA/dcgm-exporter
@@ -286,6 +291,11 @@ ENTRYPOINT ["/usr/local/dcgm/dcgm-exporter-entrypoint.sh"]
 # Distroless helper stage - builds full Ubuntu container with DCGM libraries
 #####
 FROM --platform=$TARGETARCH nvcr.io/nvidia/cuda:13.2.1-base-ubuntu22.04 AS runtime-distroless-helper
+
+# Fail on errors in piped RUN commands (hadolint DL4006).
+# /bin/bash is a symlink to /usr/bin/bash on usrmerged Debian/Ubuntu;
+# we use /bin/bash here so hadolint recognises the pipefail SHELL.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG TARGETARCH
 


### PR DESCRIPTION
What: add `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` to stages with piped `RUN` commands.
Why: without `pipefail`, a non-zero exit before the last pipe segment is silently dropped — a failed download or a bad checksum can produce a green build.
How: one `SHELL` directive at the top of each stage that contains a pipe:
- `docker/Dockerfile`: `builder` (line 20) and `runtime-distroless-helper` (line 288).
- `.devcontainer/Dockerfile`: single stage.

Note on the path: the canonical bash path on usrmerged Debian/Ubuntu is `/usr/bin/bash`; `/bin/bash` is a symlink to it. We use `/bin/bash` because hadolint pattern-matches that literal string to recognise the pipefail SHELL — `/usr/bin/bash` makes hadolint re-flag DL4006 on every piped RUN even though pipefail is active. Each SHELL directive carries a short comment explaining this trade-off.

Found by: hadolint 2.14.0 (Dockerfile linter), rule **DL4006** — *Set the SHELL option `-o pipefail` before `RUN` with a pipe in it*.