### PR TITLE
docker: COPY absolute dest in distroless (hadolint DL3045)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -331,7 +331,7 @@ LABEL summary="Exports GPU Metrics to Prometheus"
 LABEL description="See summary"
 
 # Copy binary and configs
-COPY --chown=root:root --chmod=644 ./LICENSE ./licenses/LICENSE
+COPY --chown=root:root --chmod=644 ./LICENSE /licenses/LICENSE
 COPY --from=builder --chown=root:root --chmod=755 /usr/bin/dcgm-exporter /usr/bin/
 COPY --chown=root:root --chmod=755 etc /etc/dcgm-exporter
 


### PR DESCRIPTION
What: change a relative `COPY` destination to absolute in the `runtime-distroless` stage.
Why: relative destinations depend on whatever `WORKDIR` the base image sets; if the base image changes, the file lands in a different place.
How: `./licenses/LICENSE` → `/licenses/LICENSE` in `docker/Dockerfile:334`.

Found by: hadolint 2.14.0, rule **DL3045** — *COPY to a relative destination without WORKDIR set*.