### PR TITLE
devcontainer: useradd -l (hadolint DL3046)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 # Create a user 'developer' with UID=1000, add to 'developer' group, and add to 'sudo' group
 RUN groupadd -g $USER_GID $USERNAME && \
-	useradd -m -u $USER_GID -g $USERNAME -s /bin/bash $USERNAME && \
+	useradd -m -l -u $USER_GID -g $USERNAME -s /bin/bash $USERNAME && \
 	usermod -aG sudo $USERNAME
 # Allow 'developer' to use sudo without a password
 RUN echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers


### PR DESCRIPTION
What: add `-l` to the devcontainer's `useradd` invocation.
Why: without `-l`, `useradd` may create a multi-gigabyte sparse `/var/log/lastlog` on high UIDs. UID 1000 is fine today but `-l` is the safe default and essentially free.
How: add the flag in `.devcontainer/Dockerfile:8`.

Found by: hadolint 2.14.0, rule **DL3046** — *`useradd` without flag `-l` and high UID will result in excessively large image*.
