### PR TITLE
server: thread r.Context() through render (golangci-lint contextcheck)

### DIFF
--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -246,7 +246,8 @@ func (s *MetricsServer) fatal() {
 	os.Exit(1)
 }
 
-func (s *MetricsServer) Metrics(w http.ResponseWriter, _ *http.Request) {
+func (s *MetricsServer) Metrics(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
 	currentRegistry := s.GetRegistry()
@@ -258,7 +259,7 @@ func (s *MetricsServer) Metrics(w http.ResponseWriter, _ *http.Request) {
 		return
 	}
 	var buf bytes.Buffer
-	err = s.render(&buf, metricGroups)
+	err = s.render(ctx, &buf, metricGroups)
 	if err != nil {
 		http.Error(w, internalServerError, http.StatusInternalServerError)
 		return
@@ -271,8 +272,13 @@ func (s *MetricsServer) Metrics(w http.ResponseWriter, _ *http.Request) {
 	}
 }
 
-func (s *MetricsServer) render(w io.Writer, metricGroups registry.MetricsByCounterGroup) error {
+func (s *MetricsServer) render(ctx context.Context, w io.Writer, metricGroups registry.MetricsByCounterGroup) error {
 	for group, metrics := range metricGroups {
+		// Honour scrape cancellation between metric groups so a timed-out
+		// Prometheus scrape stops wasting CPU within one group.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		deviceWatchList, exists := s.deviceWatchListManager.EntityWatchList(group)
 		if exists {
 
@@ -308,7 +314,7 @@ func (s *MetricsServer) render(w io.Writer, metricGroups registry.MetricsByCount
 			for _, transformation := range s.transformations {
 				transformErr := transformation.Process(metrics, deviceWatchList.DeviceInfo())
 				if transformErr != nil {
-					slog.LogAttrs(context.Background(), slog.LevelError, "Failed to apply transformations on metrics",
+					slog.LogAttrs(ctx, slog.LevelError, "Failed to apply transformations on metrics",
 						slog.String(logging.ErrorKey, transformErr.Error()),
 						slog.String(logging.FieldEntityGroupKey, group.String()),
 						slog.String("transformation", transformation.Name()),
@@ -325,7 +331,7 @@ func (s *MetricsServer) render(w io.Writer, metricGroups registry.MetricsByCount
 				slog.String("metrics_debug_file", metricsFile))
 			err = rendermetrics.RenderGroup(w, group, metrics)
 			if err != nil {
-				slog.LogAttrs(context.Background(), slog.LevelError, "Failed to renderGroup metrics",
+				slog.LogAttrs(ctx, slog.LevelError, "Failed to renderGroup metrics",
 					slog.String(logging.ErrorKey, err.Error()),
 					slog.String(logging.FieldEntityGroupKey, group.String()),
 					slog.Int("metrics_count", len(metrics)),


### PR DESCRIPTION
What: pass the HTTP request context through `render()` and use it for logging + cancellation.
Why: Prometheus scrapers cancel on timeout; today the daemon keeps rendering after cancellation, wasting CPU and adding shutdown latency. Also fixes two `slog.LogAttrs` calls that currently use `context.Background()` as a placeholder.
How: `Metrics(w, r)` reads `r.Context()`; `render(ctx, w, mg)`; `ctx.Err()` check between metric groups.

Found by: golangci-lint 2.12.2, linter **contextcheck** — *function calls a context-using callee without threading the caller's context*.

Follow-up: thread `ctx` into `transformation.Process` and `rendermetrics.RenderGroup` (separate PR; needs interface changes).

Behaviour change to note in release notes: a scrape cancelled mid-render now returns a truncated body. Some monitoring setups may surface this as a Prometheus parse error.
