### PR TITLE
devicemonitoring: keyed WatchedEntityKey literals (go vet composites)

### DIFF
--- a/internal/pkg/devicemonitoring/device_monitoring_test.go
+++ b/internal/pkg/devicemonitoring/device_monitoring_test.go
@@ -455,10 +455,10 @@ func TestGetMonitoredEntities(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true, 1: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
-					{0, 1}: true,
-					{1, 0}: true,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 0}: true,
+					{ParentID: 0, ChildID: 1}: true,
+					{ParentID: 1, ChildID: 0}: true,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 5, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -508,10 +508,10 @@ func TestGetMonitoredEntities(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: true, 1: true}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
-					{0, 1}: false,
-					{1, 0}: false,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 0}: true,
+					{ParentID: 0, ChildID: 1}: false,
+					{ParentID: 1, ChildID: 0}: false,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 2, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},
@@ -1037,7 +1037,7 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: true,
+					{ParentID: 0, ChildID: 1}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 1, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1062,7 +1062,7 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: false}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: true,
+					{ParentID: 0, ChildID: 1}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 1, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1079,7 +1079,7 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: false,
+					{ParentID: 0, ChildID: 1}: false,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 1, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1096,7 +1096,7 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
+					{ParentID: 0, ChildID: 0}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 1, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1115,8 +1115,8 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true, 1: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: true,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 1}: true,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 2, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1150,10 +1150,10 @@ func Test_monitorAllLinks(t *testing.T) {
 
 				watchedSwitches := map[uint]bool{0: true, 1: true}
 				watchedLinks := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
-					{0, 1}: false,
-					{1, 0}: true,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 0}: true,
+					{ParentID: 0, ChildID: 1}: false,
+					{ParentID: 1, ChildID: 0}: true,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockSwitchDeviceInfo(ctrl, 5, switchToNvLinks, watchedSwitches, watchedLinks,
 					dcgm.FE_LINK)
@@ -1311,7 +1311,7 @@ func Test_monitorAllCPUCores(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: true}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: true,
+					{ParentID: 0, ChildID: 1}: true,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 1, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},
@@ -1335,7 +1335,7 @@ func Test_monitorAllCPUCores(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: false}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: true,
+					{ParentID: 0, ChildID: 1}: true,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 1, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},
@@ -1351,7 +1351,7 @@ func Test_monitorAllCPUCores(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: true}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 1}: false,
+					{ParentID: 0, ChildID: 1}: false,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 1, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},
@@ -1368,10 +1368,10 @@ func Test_monitorAllCPUCores(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: true, 1: true}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
-					{0, 1}: true,
-					{1, 0}: true,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 0}: true,
+					{ParentID: 0, ChildID: 1}: true,
+					{ParentID: 1, ChildID: 0}: true,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 2, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},
@@ -1417,10 +1417,10 @@ func Test_monitorAllCPUCores(t *testing.T) {
 
 				watchedCPUs := map[uint]bool{0: true, 1: true}
 				watchedCores := map[testutils.WatchedEntityKey]bool{
-					{0, 0}: true,
-					{0, 1}: false,
-					{1, 0}: false,
-					{1, 1}: true,
+					{ParentID: 0, ChildID: 0}: true,
+					{ParentID: 0, ChildID: 1}: false,
+					{ParentID: 1, ChildID: 0}: false,
+					{ParentID: 1, ChildID: 1}: true,
 				}
 				return testutils.MockCPUDeviceInfo(ctrl, 2, cpuToCores, watchedCPUs, watchedCores, dcgm.FE_CPU_CORE)
 			},


### PR DESCRIPTION
What: convert 29 unkeyed `WatchedEntityKey{a, b}: true` literals to keyed form `{ParentID: a, ChildID: b}: true`.
Why: if `WatchedEntityKey` ever swaps its field order, every positional literal silently changes meaning and the tests pass with wrong data. Keyed literals make field reordering safe.
How: `sed -E -i 's/\{([0-9]+), ([0-9]+)\}: /{ParentID: \1, ChildID: \2}: /g' internal/pkg/devicemonitoring/device_monitoring_test.go`, then manual review of the 29-site diff.

Found by: **go vet** (the standard Go static-analysis tool, Go 1.26.3 toolchain), check **composites** — *struct literal uses unkeyed fields*.
