### PR TITLE
deviceinfo: tagged switch on EntityGroupId (staticcheck QF1003)

### DIFF
--- a/internal/pkg/deviceinfo/device_info.go
+++ b/internal/pkg/deviceinfo/device_info.go
@@ -183,8 +183,8 @@ func (s *Info) initializeGPUInfo(gOpt appconfig.DeviceOptions, useFakeGPUs bool)
 		for i := uint(0); i < hierarchy.Count; i++ {
 			entityID := hierarchy.EntityList[i].Entity.EntityId
 
-			if hierarchy.EntityList[i].Parent.EntityGroupId == dcgm.FE_GPU {
-
+			switch hierarchy.EntityList[i].Parent.EntityGroupId {
+			case dcgm.FE_GPU:
 				// We are adding a GPU instance
 				gpuID = hierarchy.EntityList[i].Parent.EntityId
 
@@ -197,7 +197,7 @@ func (s *Info) initializeGPUInfo(gOpt appconfig.DeviceOptions, useFakeGPUs bool)
 				s.gpus[gpuID].GPUInstances = append(s.gpus[gpuID].GPUInstances, instanceInfo)
 				entities = append(entities, dcgm.GroupEntityPair{EntityGroupId: dcgm.FE_GPU_I, EntityId: entityID})
 				instanceIndex = len(s.gpus[gpuID].GPUInstances) - 1
-			} else if hierarchy.EntityList[i].Parent.EntityGroupId == dcgm.FE_GPU_I {
+			case dcgm.FE_GPU_I:
 				// TODO (roarora): Fix this implementation as it expects Instances and Compute Instances to be reported
 				//                 in a certain sequence if, that is not the case results are incorrect.
 


### PR DESCRIPTION
What: convert the `if/else` chain on `EntityGroupId` in `initializeGPUInfo` to a tagged switch.
Why: shorter, easier to extend when DCGM adds a new entity group. A Go `switch` evaluates cases in source order, matching the original chain — no behaviour change.
How: replace `if x == FE_GPU { ... } else if x == FE_GPU_I { ... }` with `switch x { case FE_GPU: ...; case FE_GPU_I: ... }` in `internal/pkg/deviceinfo/device_info.go:186`.

Found by: staticcheck 2026.1 (v0.7.0), rule **QF1003** — *could use tagged switch on `EntityGroupId`*.
