### PR TITLE
cleanup: error string style + Fprintf (staticcheck ST1005, QF1012)

### DIFF
--- a/internal/pkg/collector/types.go
+++ b/internal/pkg/collector/types.go
@@ -161,7 +161,7 @@ func (m MetricsByCounter) GoString() string {
 		}
 		first = false
 
-		result.WriteString(fmt.Sprintf("%q: %#v", counter.FieldName, metrics))
+		fmt.Fprintf(&result, "%q: %#v", counter.FieldName, metrics)
 	}
 
 	result.WriteString("}")

--- a/internal/pkg/prerequisites/dcgmlib_rule_test.go
+++ b/internal/pkg/prerequisites/dcgmlib_rule_test.go
@@ -97,7 +97,7 @@ func Test_dcgmLibExistsRule_Validate(t *testing.T) {
 			},
 			AssertErr: func(err error) {
 				require.Error(t, err)
-				require.ErrorContains(t, err, "the libdcgm.so.4 library was not found. Install Data Center GPU Manager (DCGM).")
+				require.ErrorContains(t, err, "the libdcgm.so.4 library was not found. Install Data Center GPU Manager (DCGM)")
 			},
 		},
 		{

--- a/internal/pkg/prerequisites/variables.go
+++ b/internal/pkg/prerequisites/variables.go
@@ -38,5 +38,5 @@ var (
 	// ld-linux-x86-64.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
 	rxLDCacheEntry = regexp.MustCompile(`(?m)^(.*)\s*\(.*\)\s*=>\s*(.*)$`)
 
-	errLibdcgmNotFound = fmt.Errorf("the %s library was not found. Install Data Center GPU Manager (DCGM).", libdcgmco)
+	errLibdcgmNotFound = fmt.Errorf("the %s library was not found. Install Data Center GPU Manager (DCGM)", libdcgmco)
 )

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -1002,7 +1002,7 @@ func parseDeviceOptions(devices string) (appconfig.DeviceOptions, error) {
 	letterAndRange := strings.Split(devices, ":")
 	count := len(letterAndRange)
 	if count > 2 {
-		return dOpt, fmt.Errorf("Invalid ranged device option '%s': there can only be one specified range", devices)
+		return dOpt, fmt.Errorf("invalid ranged device option %q: there can only be one specified range", devices)
 	}
 
 	letter := letterAndRange[0]


### PR DESCRIPTION
What: three small staticcheck fixes bundled.
Why: error strings should start lowercase and not end with punctuation so callers can wrap them naturally (`fmt.Errorf("foo: %w", err)`); `Fprintf` avoids a temporary `Sprintf` allocation.
How:
- `internal/pkg/prerequisites/variables.go:41` — drop trailing period from `errLibdcgmNotFound`.
- `pkg/cmd/app.go:1005` — lowercase the `I` in *Invalid ranged device option*.
- `internal/pkg/collector/types.go:164` — `result.WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(&result, ...)`.

Also updates the `dcgmlib_rule_test.go` assertion that contained the literal old error string.

Found by:
- staticcheck 2026.1 (v0.7.0), rule **ST1005** — *error strings should not be capitalised or end with punctuation* (two sites).
- staticcheck 2026.1 (v0.7.0), rule **QF1012** — *use `fmt.Fprintf(...)` instead of `WriteString(fmt.Sprintf(...))`*.
