### PR TITLE
deviceinfo: use copy() builtin (staticcheck S1001)

### DIFF
--- a/internal/pkg/deviceinfo/device_info.go
+++ b/internal/pkg/deviceinfo/device_info.go
@@ -598,9 +598,7 @@ func getCoreArray(bitmask []uint64) []uint {
 	var cores []uint
 	bits := make([]uint64, dcgm.MAX_CPU_CORE_BITMASK_COUNT)
 
-	for i := 0; i < len(bitmask); i++ {
-		bits[i] = bitmask[i]
-	}
+	copy(bits, bitmask)
 
 	b := bitset.From(bits)
 


### PR DESCRIPTION
What: replace a manual byte-copy loop with the `copy()` builtin in `getCoreArray`.
Why: idiomatic, shorter, and slightly faster (`memmove` under the hood).
How: `for i := 0; i < len(bitmask); i++ { bits[i] = bitmask[i] }` → `copy(bits, bitmask)`.

Found by: staticcheck 2026.1 (v0.7.0), rule **S1001** — *should use `copy(to, from)` instead of a loop*.

Behaviour note: `copy()` writes `min(len(dst), len(src))`; the original loop wrote `len(bitmask)` unconditionally. If `bitmask` were ever longer than `bits`, the old code would panic and the new code silently truncates. `bits` is sized to `dcgm.MAX_CPU_CORE_BITMASK_COUNT`, which is what the kernel returns, so this case is not reachable in practice.
