### PR TITLE
dcgmprovider: drop unused moduleCleanup field (staticcheck U1000)

### DIFF
--- a/internal/pkg/dcgmprovider/dcgm.go
+++ b/internal/pkg/dcgmprovider/dcgm.go
@@ -51,8 +51,7 @@ func SetClient(d DCGM) {
 
 // dcgmProvider implements DCGM Interface
 type dcgmProvider struct {
-	shutdown      func()
-	moduleCleanup func()
+	shutdown func()
 }
 
 // newDCGMProvider initializes a new DCGM provider based on the provided configuration


### PR DESCRIPTION
What: delete the unused `moduleCleanup` field from the `dcgmProvider` struct.
Why: dead code; nothing reads or assigns it. Confirmed by `grep -rn moduleCleanup internal/ pkg/ cmd/`.
How: remove the single line in `internal/pkg/dcgmprovider/dcgm.go:55`.

Found by: staticcheck 2026.1 (v0.7.0), rule **U1000** — *unused code (struct field never used)*.
