### PR TITLE
devcontainer: use curl, drop wget (hadolint DL4001)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,11 +22,10 @@ RUN --mount=type=cache,target=/var/cache/apt \
 	libc6-dev \
 	make \
 	pkg-config \
-	wget \
 	datacenter-gpu-manager-4-core \
 	libcap2-bin \
 	&& install -m 0755 -d /etc/apt/keyrings \
-	&& wget -O /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg \
+	&& curl -fSL --retry 3 -o /etc/apt/keyrings/docker.asc https://download.docker.com/linux/ubuntu/gpg \
 	&& chmod a+r /etc/apt/keyrings/docker.asc \
 	&& echo \
 	"deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
@@ -66,10 +65,10 @@ RUN set -eux; \
 	echo >&2 "warning: current architecture ($arch) does not have a compatible Go binary release; will be building from source"; \
 	echo >&2; \
 	fi; \
-	wget -O go.tgz "$url" --progress=dot:giga; \
+	curl -fSL --retry 3 -o go.tgz "$url"; \
 	\
 	echo "Verifying SHA256 checksum..."; \
-	wget -O go.sha256 "https://dl.google.com/go/${filename}.sha256"; \
+	curl -fSL --retry 3 -o go.sha256 "https://dl.google.com/go/${filename}.sha256"; \
 	expected_sha256=$(cat go.sha256); \
 	actual_sha256=$(sha256sum go.tgz | awk '{print $1}'); \
 	if [ "$expected_sha256" != "$actual_sha256" ]; then \


### PR DESCRIPTION
What: replace all `wget` calls in the devcontainer with `curl`; drop `wget` from the apt install list.
Why: shipping two TLS clients in one image doubles the attack surface and supply-chain churn. Standardising on `curl` also silences hadolint's DL3047 because `curl` is silent off-TTY by default.
How: `wget -O X URL` → `curl -fSL --retry 3 -o X URL` (fail on HTTP 4xx/5xx, follow redirects, retry transient failures); remove `wget` from `apt-get install`.

Found by:
- hadolint 2.14.0, rule **DL4001** — *Either use Wget or Curl but not both*.
- hadolint 2.14.0, rule **DL3047** — *Avoid use of wget without progress bar* (subsumed by the wget removal).
