### PR TITLE
cmd: signal-cancellable root context + architecture doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,15 @@ package-build:
 test-integration: generate
 	go test -race -count=1 -timeout 5m -v $(TEST_ARGS) ./tests/integration/
 
+.PHONY: test-signals
+# Black-box signal handling test — runs the real binary, sends real
+# signals, scrapes real /metrics. Proves SIGTERM/SIGINT shut the daemon
+# down within a budget and SIGHUP triggers hot reload without exiting.
+# Requires libdcgm.so.4 and libnvidia-ml.so.1 at runtime — same as
+# test-integration. See tests/signals/README.md.
+test-signals: binary
+	./tests/signals/test_signals.sh
+
 .PHONY: test-coverage
 test-coverage:
 	@echo "Preparing coverage data directories..."

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ make REGISTRY=<private_registry> push
 
 * For community support, please [file a new issue](https://github.com/NVIDIA/dcgm-exporter/issues/new)
 * You can contribute by opening a [pull request](https://github.com/NVIDIA/dcgm-exporter)
+* [Context architecture](docs/CONTEXTS.md) — how `context.Context` flows through the daemon, when to add one, how to test it.
 
 ### Reporting Security Issues
 

--- a/cmd/dcgm-exporter/main.go
+++ b/cmd/dcgm-exporter/main.go
@@ -17,8 +17,11 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/NVIDIA/dcgm-exporter/pkg/cmd"
 )
@@ -26,8 +29,14 @@ import (
 var BuildVersion = "Filled by the build system"
 
 func main() {
+	// Root context, cancelled by SIGINT or SIGTERM. SIGHUP keeps flowing
+	// through SignalSource for hot reload (different semantics — see
+	// docs/CONTEXTS.md).
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
 	app := cmd.NewApp(BuildVersion)
-	if err := app.Run(os.Args); err != nil {
+	if err := app.RunContext(ctx, os.Args); err != nil {
 		slog.Error(err.Error())
 		os.Exit(1)
 	}

--- a/docs/CONTEXTS.md
+++ b/docs/CONTEXTS.md
@@ -1,0 +1,216 @@
+# Context architecture — dcgm-exporter
+
+Audience: contributors adding or reviewing code that does I/O (network, file, subprocess, channel-wait).
+
+## Why context
+
+dcgm-exporter is a long-running daemon. It needs a single, signal-cancellable root `context.Context` that propagates through every I/O path so that a shutdown signal (`SIGTERM`), a Prometheus scrape timeout, or a hung gRPC call can abort cleanly instead of waiting on per-call timeouts. Standard Go idiom — nothing exporter-specific.
+
+## Where the root is created
+
+`cmd/dcgm-exporter/main.go`:
+
+```go
+func main() {
+    // Root context, cancelled by SIGINT or SIGTERM. SIGHUP keeps flowing
+    // through SignalSource for hot reload.
+    ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+    defer stop()
+
+    app := cmd.NewApp(BuildVersion)
+    if err := app.RunContext(ctx, os.Args); err != nil {
+        slog.Error(err.Error())
+        os.Exit(1)
+    }
+}
+```
+
+`app.RunContext(ctx, …)` plumbs `ctx` into urfave/cli's `c.Context`, which the daemon's action handler reads and threads onward.
+
+## Signal handling — two channels by design
+
+dcgm-exporter handles three signals; they are intentionally routed differently:
+
+| Signal | Mechanism | Semantics |
+| --- | --- | --- |
+| `SIGINT` | `signal.NotifyContext` → cancels root ctx | Shutdown |
+| `SIGTERM` | `signal.NotifyContext` → cancels root ctx | Shutdown |
+| `SIGHUP` | `cmd.SignalSource` channel | Hot reload (re-read counters CSV, rebuild registry, atomic swap — daemon stays up) |
+
+This split is deliberate. Shutdown and reload are different events; conflating them in one mechanism would either break reload (operators rely on `kill -HUP $(pidof dcgm-exporter)` for zero-downtime config changes) or weaken shutdown cancellation. Do not "fix" this by folding SIGHUP into the ctx.
+
+## Propagation tree
+
+```
+cmd/dcgm-exporter/main.go
+  ctx, stop = signal.NotifyContext(Background, SIGINT, SIGTERM)
+    │
+    └── app.RunContext(ctx, os.Args)
+          │
+          └── c.Context = ctx                          (urfave/cli plumbs this)
+                │
+                └── action(c)
+                      │
+                      └── stdout.Capture(c.Context, …)
+                            │
+                            └── startDCGMExporter(c)
+                                  │
+                                  └── StartDCGMExporterWithSignalSource(c, sigSource)
+                                        │
+                                        ├── ctx := c.Context                  (root for the daemon)
+                                        │     │
+                                        │     ├── buildRegistry(ctx, …)
+                                        │     ├── getCounters(ctx, …)          ConfigMap reader honours ctx
+                                        │     ├── metricsServer.Run(ctx, stop)
+                                        │     │     │
+                                        │     │     └── render(ctx, …)
+                                        │     │           └── transformer.Process(ctx, …)
+                                        │     │                 └── PodMapper.listPods(ctx, conn)
+                                        │     │                       └── client.List(ctx, …)   gRPC respects parent
+                                        │     │
+                                        │     └── draManager = NewDRAResourceSliceManager(ctx)
+                                        │           └── factory.Start(ctx.Done())   informer respects parent
+                                        │
+                                        ├── watcherCtx, _ = context.WithCancel(ctx)
+                                        │     ├── runWatcher(watcherCtx, fileWatcher, onChange)
+                                        │     ├── runGPUWatcher(watcherCtx, gpuWatcher, onChange)
+                                        │     ├── hotReload(watcherCtx, …)              triggered by SIGHUP
+                                        │     └── handleGPUTopologyChange(watcherCtx, …)
+                                        │
+                                        └── sigSource.Signals() loop              SIGHUP → hotReload
+```
+
+Three kinds of arrows in this tree:
+
+- **Inherited** (`c.Context = ctx`, `ctx := c.Context`): the root flows down unchanged.
+- **`context.WithCancel(parent)`** (`watcherCtx`): a child whose cancel is wired to a specific subsystem's shutdown path.
+- **`context.WithTimeout(parent, …)`** (per-call): a child with a per-operation deadline. The parent's cancellation still propagates.
+
+## Conventions for new code
+
+1. **Any function that does I/O** — network, file, subprocess, channel-wait beyond a few ms — MUST take `ctx context.Context` as its first parameter, name it `ctx`, and honour cancellation (check `ctx.Err()` between blocking operations; pass `ctx` to downstream calls).
+2. **Never write `context.Background()` in production code.** The only exceptions are documented in §"Acceptable Background() sites" below. Tests are excluded — they use `context.Background()` as a sentinel for "no parent" all the time, which is fine.
+3. **Never write `context.TODO()` in production code, period.** `context.TODO()` is a marker for "I haven't decided what context to use yet" — that's a bug.
+4. **Subprocess invocations** go through `internal/pkg/exec`. See its `README.md` for the wrapper policy. The wrapper enforces `CommandContext`, so subprocesses always honour cancellation.
+5. **Per-call deadlines** wrap the inherited ctx with `context.WithTimeout(parent, …)`. Do not start the deadline from `context.Background()`; that orphans the call from the root and breaks shutdown.
+6. **gRPC, Kubernetes, HTTP clients** all accept a `context.Context`. Pass it through. They handle the cancellation internally.
+
+## Acceptable `context.Background()` sites
+
+After this refactor, the **only** production sites that use `context.Background()` are:
+
+| Site | Why |
+| --- | --- |
+| `cmd/dcgm-exporter/main.go` (the root) | API requirement — `signal.NotifyContext(parent, …)` needs a parent; `context.Background()` is the convention for the process root. |
+| `internal/pkg/devicewatcher/device_watcher.go:82,405` | Inside `Cleanup` / inline cleanup callback. No caller ctx is in scope. `slog.LogAttrs` uses the ctx only for handler attribute extraction, not for cancellation, so `context.Background()` is harmless here. |
+
+Any other `context.Background()` in production code is a bug. The static analysis pipeline (`golangci-lint` with `contextcheck` enabled) gates new offenders.
+
+## Testing patterns
+
+Match the repo idiom: table-driven, stretchr/testify, `t.Run(tc.name, …)`. Cover positive, negative, boundary, and corner cases.
+
+### Recipe
+
+```go
+func TestThingHonoursContext(t *testing.T) {
+    cases := []struct {
+        name        string
+        prepCtx     func() (context.Context, context.CancelFunc)
+        wantErrKind error          // nil, context.Canceled, context.DeadlineExceeded
+        wantTimely  bool           // returns within a tight bound after cancel
+    }{
+        {
+            name: "positive: fresh ctx, runs to completion",
+            prepCtx: func() (context.Context, context.CancelFunc) {
+                return context.WithCancel(context.Background())
+            },
+            wantErrKind: nil,
+            wantTimely:  true,
+        },
+        {
+            name: "negative: pre-cancelled ctx aborts immediately",
+            prepCtx: func() (context.Context, context.CancelFunc) {
+                ctx, cancel := context.WithCancel(context.Background())
+                cancel()
+                return ctx, func() {}
+            },
+            wantErrKind: context.Canceled,
+            wantTimely:  true,
+        },
+        {
+            name: "boundary: cancel mid-call propagates",
+            prepCtx: func() (context.Context, context.CancelFunc) {
+                ctx, cancel := context.WithCancel(context.Background())
+                go func() { time.Sleep(50 * time.Millisecond); cancel() }()
+                return ctx, func() {}
+            },
+            wantErrKind: context.Canceled,
+            wantTimely:  true,
+        },
+        {
+            name: "corner: deadline shorter than work",
+            prepCtx: func() (context.Context, context.CancelFunc) {
+                return context.WithTimeout(context.Background(), 50*time.Millisecond)
+            },
+            wantErrKind: context.DeadlineExceeded,
+            wantTimely:  true,
+        },
+    }
+
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            ctx, cancel := tc.prepCtx()
+            defer cancel()
+
+            start := time.Now()
+            err := thingUnderTest(ctx)
+            elapsed := time.Since(start)
+
+            if tc.wantErrKind == nil {
+                assert.NoError(t, err)
+            } else {
+                assert.ErrorIs(t, err, tc.wantErrKind)
+            }
+            if tc.wantTimely {
+                assert.Less(t, elapsed, 150*time.Millisecond,
+                    "ctx cancellation did not propagate")
+            }
+        })
+    }
+}
+```
+
+### Existing examples
+
+- `internal/pkg/watcher/gpu_test.go` — ctx-cancel test for the GPU bind-unbind watcher.
+- `internal/pkg/stdout/capture_test.go` — ctx wrapping inside `stdout.Capture`.
+- `pkg/cmd/app_test.go` — `TestActionUsesCliContext` for the daemon entry-point chain.
+
+## How to verify your change
+
+```bash
+make test-main          # unit tests, no GPU needed
+make lint               # golangci-lint with contextcheck enabled
+
+# Manual smoke (any host, no GPU needed for shutdown path):
+./dcgm-exporter &
+sleep 1
+kill -TERM $!           # exits within ~1 second
+```
+
+For the integration suite (which needs a real GPU + DCGM):
+
+```bash
+make test-integration
+```
+
+## Maintenance
+
+When you add a new context-aware function:
+
+1. Put `ctx context.Context` as the first parameter.
+2. Pass `ctx` (or a `WithTimeout(ctx, …)` / `WithCancel(ctx)` child) to every downstream call that accepts one.
+3. If your function is long-running, sprinkle `if err := ctx.Err(); err != nil { return err }` between blocking operations.
+4. Add a table-driven test from the recipe above.
+5. Run `make lint` — `contextcheck` will flag any context discontinuity.

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -392,7 +392,7 @@ func newOSWatcher(sigs ...os.Signal) (chan os.Signal, func()) {
 }
 
 func action(c *cli.Context) (err error) {
-	return stdout.Capture(context.Background(), func() error {
+	return stdout.Capture(c.Context, func() error {
 		// The purpose of this function is to capture any panic that may occur
 		// during initialization and return an error.
 		defer func() {
@@ -490,7 +490,11 @@ func StartDCGMExporterWithSignalSource(c *cli.Context, sigSource SignalSource) e
 
 	slog.Info("DCGM successfully initialized!")
 
-	ctx := context.Background()
+	// Root context, plumbed from cmd/dcgm-exporter/main.go via
+	// signal.NotifyContext + app.RunContext. Cancelled by SIGINT or
+	// SIGTERM so the watcher / gRPC / informer subtrees below inherit
+	// shutdown cancellation. See docs/CONTEXTS.md.
+	ctx := c.Context
 
 	// Query DCGM profiling metrics at startup
 	// This is re-queried on every hot reload to handle GPU changes
@@ -522,8 +526,10 @@ func StartDCGMExporterWithSignalSource(c *cli.Context, sigSource SignalSource) e
 
 	slog.Info("HTTP server started - ready to serve metrics")
 
-	// Start watchers
-	watcherCtx, watcherCancel := context.WithCancel(context.Background())
+	// Start watchers — derive from the startup ctx so a SIGINT/SIGTERM
+	// also stops the file / GPU bind-unbind watchers below in addition
+	// to the explicit watcherCancel() in the shutdown path.
+	watcherCtx, watcherCancel := context.WithCancel(ctx)
 	var watcherWg sync.WaitGroup
 
 	// File watcher (config changes) - hot reload on change
@@ -543,23 +549,33 @@ func StartDCGMExporterWithSignalSource(c *cli.Context, sigSource SignalSource) e
 		runGPUWatcher(watcherCtx, gpuWatcher, metricsServer, c, dcgmCleanup, &watcherWg)
 	}
 
-	// Wait for shutdown signal (SIGTERM, SIGINT) - ignore SIGHUP for compatibility
+	// Wait for shutdown signal (SIGTERM, SIGINT) or root ctx cancellation.
+	// SIGHUP triggers hot reload and continues the loop.
 	sigs := sigSource.Signals()
+shutdownLoop:
 	for {
-		sig := <-sigs
-		slog.Info("Received signal", slog.String("signal", sig.String()))
+		select {
+		case sig := <-sigs:
+			slog.Info("Received signal", slog.String("signal", sig.String()))
 
-		if sig == syscall.SIGHUP {
-			// SIGHUP triggers hot reload instead of full restart
-			slog.Info("SIGHUP received - triggering hot reload")
-			if err := hotReload(watcherCtx, metricsServer, c, dcgmCleanup); err != nil {
-				slog.Error("Hot reload failed", slog.String("error", err.Error()))
+			if sig == syscall.SIGHUP {
+				// SIGHUP triggers hot reload instead of full restart
+				slog.Info("SIGHUP received - triggering hot reload")
+				if err := hotReload(watcherCtx, metricsServer, c, dcgmCleanup); err != nil {
+					slog.Error("Hot reload failed", slog.String("error", err.Error()))
+				}
+				continue
 			}
-			continue
-		}
 
-		// SIGTERM/SIGINT/SIGQUIT - graceful shutdown
-		break
+			// SIGTERM/SIGINT/SIGQUIT - graceful shutdown
+			break shutdownLoop
+		case <-ctx.Done():
+			// Root context cancelled (signal.NotifyContext fired upstream,
+			// or a parent caller cancelled the cli.Context). Shut down.
+			slog.Info("Root context cancelled - shutting down",
+				slog.String("err", ctx.Err().Error()))
+			break shutdownLoop
+		}
 	}
 
 	// Graceful shutdown

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -17,9 +17,12 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/stretchr/testify/assert"
@@ -32,6 +35,7 @@ import (
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/counters"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/devicewatchlistmanager"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/stdout"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/testutils"
 )
 
@@ -364,6 +368,113 @@ func Test_contextToConfig_DumpConfig(t *testing.T) {
 
 			// Assert equality against the config returned by contextToConfig
 			assert.Equal(t, tt.expectedConfig, config.DumpConfig)
+		})
+	}
+}
+
+// TestActionUsesCliContext verifies that the daemon's action chain
+// (action → stdout.Capture → callback) honours cancellation of the
+// cli.Context's root context. The action function reads c.Context (set by
+// main.go via signal.NotifyContext + app.RunContext); cancellation of
+// that context must propagate into the wrapped callback within a tight
+// time bound.
+//
+// See docs/CONTEXTS.md for the full propagation tree.
+func TestActionUsesCliContext(t *testing.T) {
+	// Sleep that respects context cancellation. Returns ctx.Err() on
+	// cancel; returns nil after the full duration elapses. Modelled on
+	// the standard pattern in long-running I/O paths.
+	ctxSleep := func(ctx context.Context, d time.Duration) error {
+		select {
+		case <-time.After(d):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	cases := []struct {
+		name        string
+		prepCtx     func() (context.Context, context.CancelFunc)
+		workTime    time.Duration
+		wantErrKind error
+		wantQuick   bool // did the call return well before workTime?
+	}{
+		{
+			name: "positive: fresh ctx, callback runs to completion",
+			prepCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+			workTime:    20 * time.Millisecond,
+			wantErrKind: nil,
+			wantQuick:   false,
+		},
+		{
+			name: "negative: pre-cancelled ctx aborts immediately",
+			prepCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx, func() {}
+			},
+			workTime:    500 * time.Millisecond,
+			wantErrKind: context.Canceled,
+			wantQuick:   true,
+		},
+		{
+			name: "boundary: ctx cancelled mid-callback propagates",
+			prepCtx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				go func() { time.Sleep(30 * time.Millisecond); cancel() }()
+				return ctx, func() {}
+			},
+			workTime:    500 * time.Millisecond,
+			wantErrKind: context.Canceled,
+			wantQuick:   true,
+		},
+		{
+			name: "corner: ctx with deadline shorter than work fires DeadlineExceeded",
+			prepCtx: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 30*time.Millisecond)
+			},
+			workTime:    500 * time.Millisecond,
+			wantErrKind: context.DeadlineExceeded,
+			wantQuick:   true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := tc.prepCtx()
+			defer cancel()
+
+			// Build a cli.Context whose Context field is the cancellable one.
+			// cli.NewContext(app, set, parent) inherits parent's Context.
+			set := flag.NewFlagSet("test", 0)
+			parent := &cli.Context{Context: ctx}
+			cliCtx := cli.NewContext(NewApp(), set, parent)
+			require.Same(t, ctx, cliCtx.Context,
+				"cli.Context.Context must be the ctx we passed in")
+
+			// Mirror the production action() wrapping: stdout.Capture(c.Context, fn).
+			// The fn here stands in for startDCGMExporter — it just sleeps
+			// respecting ctx so the test is fast and predictable.
+			start := time.Now()
+			err := stdout.Capture(cliCtx.Context, func() error {
+				return ctxSleep(cliCtx.Context, tc.workTime)
+			})
+			elapsed := time.Since(start)
+
+			if tc.wantErrKind == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.True(t, errors.Is(err, tc.wantErrKind),
+					"err = %v, want %v", err, tc.wantErrKind)
+			}
+			if tc.wantQuick {
+				assert.Less(t, elapsed, tc.workTime/2,
+					"ctx cancellation/timeout did not propagate within budget; elapsed=%v workTime=%v",
+					elapsed, tc.workTime)
+			}
 		})
 	}
 }

--- a/tests/integration/start_read_test.go
+++ b/tests/integration/start_read_test.go
@@ -17,6 +17,7 @@
 package integration
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -87,4 +88,85 @@ func TestStartAndReadMetrics(t *testing.T) {
 	mf, err := parser.TextToMetricFamilies(strings.NewReader(metricsResp))
 	require.NoError(t, err)
 	require.Greater(t, len(mf), 0, "expected number of metrics more than 0")
+}
+
+// TestShutdownViaContextCancel verifies that cancelling the root
+// cli.Context shuts the daemon down within the same budget as a SIGTERM.
+// This is the ctx-driven sibling of TestStartAndReadMetrics; together
+// they prove that both shutdown paths (signal channel and ctx cancel)
+// reach the same place. See docs/CONTEXTS.md.
+func TestShutdownViaContextCancel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	port := getRandomAvailablePort(t)
+
+	// SignalSource present but unused — we drive shutdown via ctx cancel.
+	// Still need it as a defer-cleanup safety net in case the test fails
+	// before the cancel and we want to make sure the daemon goroutine ends.
+	testSigs := cmd.NewTestSignalSource()
+
+	cliCtx := createTestCLIContext(t, "./testdata/default-counters.csv", fmt.Sprintf(":%d", port))
+
+	// Override cli.Context.Context with a cancellable ctx so the test
+	// can simulate signal.NotifyContext firing from main.go.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cliCtx.Context = ctx
+
+	appDone := make(chan error, 1)
+	go func() {
+		appDone <- cmd.StartDCGMExporterWithSignalSource(cliCtx, testSigs)
+	}()
+
+	// Belt-and-suspenders: SIGTERM if ctx-cancel didn't shut things down.
+	defer func() {
+		select {
+		case <-appDone:
+			// already shut down
+		default:
+			t.Log("daemon still running after test body; sending SIGTERM as cleanup")
+			testSigs.SendSignal(syscall.SIGTERM)
+			select {
+			case <-appDone:
+			case <-time.After(10 * time.Second):
+				t.Log("warning: app did not shut down within timeout")
+			}
+		}
+	}()
+
+	// Wait until /metrics is responsive (proves the daemon started).
+	t.Logf("Waiting for metrics endpoint on http://localhost:%d/metrics", port)
+	metricsResp, _ := retry.DoWithData(
+		func() (string, error) {
+			resp, _, err := httpGet(t, fmt.Sprintf("http://localhost:%d/metrics", port))
+			if err != nil {
+				return "", err
+			}
+			if len(resp) == 0 {
+				return "", errors.New("empty response")
+			}
+			return resp, nil
+		},
+		retry.Attempts(10),
+		retry.MaxDelay(10*time.Second),
+	)
+	require.NotEmpty(t, metricsResp, "daemon never produced metrics")
+
+	// Drive shutdown by cancelling the root ctx.
+	t.Log("Cancelling root ctx to drive shutdown")
+	start := time.Now()
+	cancel()
+
+	select {
+	case err := <-appDone:
+		elapsed := time.Since(start)
+		t.Logf("Daemon exited after ctx cancel in %v (err=%v)", elapsed, err)
+		require.Less(t, elapsed, 10*time.Second,
+			"ctx-cancel shutdown took too long; either ctx is not threaded through "+
+				"to the shutdown loop, or some subsystem is hung")
+	case <-time.After(10 * time.Second):
+		t.Fatal("daemon did not shut down within 10s of ctx cancellation")
+	}
 }

--- a/tests/signals/README.md
+++ b/tests/signals/README.md
@@ -1,0 +1,53 @@
+# Signal handling tests
+
+Black-box behavioural tests that prove `dcgm-exporter` honours `SIGTERM`, `SIGINT`, and `SIGHUP` correctly. Run the real binary, send real signals, scrape real `/metrics`. See `docs/CONTEXTS.md` for the context-propagation model the tests exercise.
+
+## What's tested
+
+| Test | Signal | Expectation |
+| --- | --- | --- |
+| 1 | `SIGTERM` | Daemon exits within `SHUTDOWN_BUDGET_SECONDS` (default 5 s). |
+| 2 | `SIGINT` | Daemon exits within budget. |
+| 3 | `SIGHUP` | Daemon performs hot reload, stays running, `/metrics` keeps responding. |
+| 4 | 3 × `SIGHUP` | Daemon survives all three reloads, `/metrics` still responds. |
+
+## Requirements
+
+- `libdcgm.so.4` and `libnvidia-ml.so.1` discoverable by the dynamic linker (NVIDIA DCGM installed, or running inside an `nvidia-container-runtime` container).
+- `curl` on `PATH`.
+- The `dcgm-exporter` binary at `cmd/dcgm-exporter/dcgm-exporter` (produced by `make binary`).
+
+### NixOS
+
+The script auto-detects NixOS (`/etc/NIXOS`) and prepends the standard NixOS library locations to `LD_LIBRARY_PATH`:
+
+- `/run/opengl-driver/lib` for `libnvidia-ml.so.1` (NVIDIA driver, NixOS convention).
+- The first `libdcgm.so.4` found under `/nix/store/*/lib` (e.g. the `pkgs.dcgm` package).
+
+Any pre-existing `LD_LIBRARY_PATH` entries are preserved. To pin a specific DCGM version, export `LD_LIBRARY_PATH` yourself before running — the auto-detection only prepends paths for libs it cannot already find.
+
+If `PORT` (default `9499`) is already bound (e.g. by a running `dcgm-exporter.service`), the script auto-increments up to 20 ports and runs on the first free one.
+
+## Running
+
+From the repo root:
+
+```bash
+make test-signals
+```
+
+Or directly (after `make binary`):
+
+```bash
+./tests/signals/test_signals.sh
+```
+
+## Environment overrides
+
+| Var | Default | Purpose |
+| --- | --- | --- |
+| `BIN` | `cmd/dcgm-exporter/dcgm-exporter` | Path to the daemon binary. |
+| `PORT` | `9499` | HTTP port to bind. Off the canonical 9400 to avoid clashing with a running production exporter. |
+| `COUNTERS` | `etc/default-counters.csv` | Counters CSV. |
+| `SHUTDOWN_BUDGET_SECONDS` | `5` | Max time allowed between signal and exit. |
+| `STARTUP_TIMEOUT_SECONDS` | `30` | Max time waiting for `/metrics` to respond. |

--- a/tests/signals/test_signals.sh
+++ b/tests/signals/test_signals.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+#
+# Black-box behavioural test for dcgm-exporter signal handling.
+#
+# Proves end-to-end (no Go test harness — just the real binary, real
+# signals, real HTTP scrapes) that:
+#
+#   1. SIGTERM            → daemon shuts down cleanly within budget.
+#   2. SIGINT             → daemon shuts down cleanly within budget.
+#   3. SIGHUP             → daemon performs hot reload, stays running,
+#                           /metrics keeps responding.
+#   4. Multiple SIGHUPs   → all reloads complete, daemon survives.
+#
+# Requirements:
+#   - libdcgm.so.4 and libnvidia-ml.so.1 discoverable by the dynamic
+#     linker (NVIDIA DCGM installed on the host, or run inside an
+#     nvidia-container-runtime container).
+#   - curl on PATH.
+#   - The dcgm-exporter binary present at $BIN (defaults to
+#     cmd/dcgm-exporter/dcgm-exporter; `make binary` produces it).
+#
+# Usage:
+#   make test-signals
+#     (builds the binary, then runs this script)
+#
+#   ./tests/signals/test_signals.sh
+#     (assumes the binary is already built)
+#
+# Environment overrides:
+#   BIN                       path to the dcgm-exporter binary
+#   PORT                      HTTP port (default 9499 — off the canonical 9400)
+#   COUNTERS                  path to counters CSV
+#   SHUTDOWN_BUDGET_SECONDS   max time allowed between signal and exit (default 5)
+#   STARTUP_TIMEOUT_SECONDS   max time waiting for /metrics to respond (default 30)
+
+set -uo pipefail
+
+#─────────────────────────────────────────────────────────────────────────
+# Config
+#─────────────────────────────────────────────────────────────────────────
+
+BIN=${BIN:-cmd/dcgm-exporter/dcgm-exporter}
+PORT=${PORT:-9499}
+COUNTERS=${COUNTERS:-etc/default-counters.csv}
+SHUTDOWN_BUDGET_SECONDS=${SHUTDOWN_BUDGET_SECONDS:-5}
+STARTUP_TIMEOUT_SECONDS=${STARTUP_TIMEOUT_SECONDS:-30}
+
+# METRICS_URL is assigned after the port-availability check below; using
+# it before that would risk pointing at a stale port.
+METRICS_URL=""
+
+#─────────────────────────────────────────────────────────────────────────
+# Output helpers
+#─────────────────────────────────────────────────────────────────────────
+
+if [ -t 1 ]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    NC=$'\033[0m'
+else
+    RED='' GREEN='' YELLOW='' NC=''
+fi
+
+pass() { printf '%sPASS%s: %s\n' "$GREEN" "$NC" "$*"; }
+fail() { printf '%sFAIL%s: %s\n' "$RED" "$NC" "$*" >&2; exit 1; }
+info() { printf '%s---%s %s\n' "$YELLOW" "$NC" "$*"; }
+
+#─────────────────────────────────────────────────────────────────────────
+# Daemon lifecycle
+#─────────────────────────────────────────────────────────────────────────
+
+DAEMON_PID=""
+DAEMON_LOG=""
+
+# wait_for_metrics PID
+#   Polls /metrics until it responds or the daemon dies.
+wait_for_metrics() {
+    local pid=$1
+    local start=$SECONDS
+    while true; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+            local exit_code
+            wait "$pid" 2>/dev/null
+            exit_code=$?
+            echo
+            echo "===== daemon log ====="
+            cat "$DAEMON_LOG"
+            echo "===== end log ====="
+            fail "daemon (pid=$pid) died before /metrics responded (exit=$exit_code)"
+        fi
+        if curl -fsSL --max-time 2 "$METRICS_URL" >/dev/null 2>&1; then
+            return 0
+        fi
+        if (( SECONDS - start > STARTUP_TIMEOUT_SECONDS )); then
+            fail "/metrics did not respond within ${STARTUP_TIMEOUT_SECONDS}s"
+        fi
+        sleep 0.5
+    done
+}
+
+start_daemon() {
+    DAEMON_LOG=$(mktemp -t dcgm-exporter-signal-test.XXXXXX.log)
+    info "Starting dcgm-exporter on :$PORT (log: $DAEMON_LOG)"
+    "$BIN" --collectors "$COUNTERS" --address ":$PORT" \
+        >"$DAEMON_LOG" 2>&1 &
+    DAEMON_PID=$!
+    info "Daemon pid=$DAEMON_PID"
+    wait_for_metrics "$DAEMON_PID"
+    info "Daemon is serving /metrics"
+}
+
+# stop_daemon_with_signal SIG
+#   Sends SIG to the daemon and asserts it exits within budget.
+stop_daemon_with_signal() {
+    local sig=$1
+    local start=$SECONDS
+    info "Sending SIG${sig} to pid=${DAEMON_PID}"
+    kill -s "$sig" "$DAEMON_PID"
+    while kill -0 "$DAEMON_PID" 2>/dev/null; do
+        local elapsed=$(( SECONDS - start ))
+        if (( elapsed > SHUTDOWN_BUDGET_SECONDS )); then
+            kill -KILL "$DAEMON_PID" 2>/dev/null || true
+            echo
+            echo "===== daemon log ====="
+            cat "$DAEMON_LOG"
+            echo "===== end log ====="
+            fail "daemon did not exit within ${SHUTDOWN_BUDGET_SECONDS}s after SIG${sig}"
+        fi
+        sleep 0.1
+    done
+    wait "$DAEMON_PID" 2>/dev/null || true
+    local elapsed=$(( SECONDS - start ))
+    pass "daemon exited within ${elapsed}s after SIG${sig}"
+    DAEMON_PID=""
+    rm -f "$DAEMON_LOG"
+}
+
+cleanup() {
+    if [ -n "${DAEMON_PID:-}" ] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+        info "Cleaning up daemon pid=$DAEMON_PID"
+        kill -KILL "$DAEMON_PID" 2>/dev/null || true
+    fi
+    if [ -n "${DAEMON_LOG:-}" ] && [ -f "$DAEMON_LOG" ]; then
+        rm -f "$DAEMON_LOG"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+#─────────────────────────────────────────────────────────────────────────
+# Pre-flight checks
+#─────────────────────────────────────────────────────────────────────────
+
+if [ ! -x "$BIN" ]; then
+    fail "binary not found or not executable: $BIN (run 'make binary' first)"
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    fail "curl not on PATH (required for /metrics scrape)"
+fi
+if [ ! -f "$COUNTERS" ]; then
+    fail "counters file not found: $COUNTERS"
+fi
+
+# port_in_use PORT
+#   Returns 0 if something is listening on PORT, non-zero otherwise.
+#   Uses bash's /dev/tcp pseudo-device (no external deps).
+port_in_use() {
+    local p=$1
+    (echo > "/dev/tcp/127.0.0.1/$p") 2>/dev/null
+}
+
+# Bump PORT until we find a free one. Caps at +20 to avoid wandering
+# off if the user's machine has a dense local-port population (e.g.
+# kubernetes node-ports). The default 9499 is one off from the
+# canonical 9400 so a running dcgm-exporter service doesn't clash.
+original_port=$PORT
+max_attempts=20
+attempt=0
+while port_in_use "$PORT"; do
+    info "port $PORT already in use; trying $((PORT + 1))"
+    PORT=$((PORT + 1))
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge "$max_attempts" ]; then
+        fail "no free port found in range ${original_port}-${PORT}; set PORT=NNNN to pick one explicitly"
+    fi
+done
+if [ "$PORT" -ne "$original_port" ]; then
+    info "Using port $PORT (default $original_port was in use)"
+fi
+METRICS_URL="http://localhost:${PORT}/metrics"
+readonly METRICS_URL
+
+# Runtime-library detection. The daemon dlopens libdcgm.so.4 and
+# libnvidia-ml.so.1 at startup. Behaviour per environment:
+#
+#   * Standard Linux (Ubuntu/RHEL/etc.): rely on ldconfig + standard
+#     loader paths. Warn (not fail) if missing.
+#   * NixOS: ldconfig doesn't see /nix/store libs. Auto-populate
+#     LD_LIBRARY_PATH from /run/opengl-driver/lib (NVIDIA driver) and
+#     the first libdcgm.so.4 found in /nix/store. Caller-set
+#     LD_LIBRARY_PATH wins.
+nixos=0
+if [ -e /etc/NIXOS ] || [ -d /nix/store ]; then
+    nixos=1
+fi
+
+if [ "$nixos" -eq 1 ]; then
+    # Check whether the required libs are already reachable via the
+    # caller's LD_LIBRARY_PATH (e.g. inside a nix-shell that already
+    # has DCGM). If not, prepend the standard NixOS locations.
+    needs_dcgm=1
+    needs_nvml=1
+    if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+        IFS=':' read -r -a ld_dirs <<< "$LD_LIBRARY_PATH"
+        for d in "${ld_dirs[@]}"; do
+            [ -e "$d/libdcgm.so.4" ] && needs_dcgm=0
+            [ -e "$d/libnvidia-ml.so.1" ] && needs_nvml=0
+        done
+    fi
+
+    if [ "$needs_dcgm" -eq 1 ] || [ "$needs_nvml" -eq 1 ]; then
+        info "NixOS detected; auto-configuring LD_LIBRARY_PATH for DCGM/NVML"
+        new_paths=()
+        if [ "$needs_nvml" -eq 1 ] && [ -d /run/opengl-driver/lib ]; then
+            new_paths+=(/run/opengl-driver/lib)
+        fi
+        if [ "$needs_dcgm" -eq 1 ]; then
+            dcgm_lib=$(find /nix/store -maxdepth 4 -name 'libdcgm.so.4' -printf '%h\n' 2>/dev/null | head -1)
+            if [ -n "$dcgm_lib" ]; then
+                new_paths+=("$dcgm_lib")
+            fi
+        fi
+        if [ "${#new_paths[@]}" -gt 0 ]; then
+            prefix=$(IFS=:; echo "${new_paths[*]}")
+            if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+                LD_LIBRARY_PATH="$prefix:$LD_LIBRARY_PATH"
+            else
+                LD_LIBRARY_PATH="$prefix"
+            fi
+            export LD_LIBRARY_PATH
+            info "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
+        fi
+    fi
+fi
+
+if command -v ldconfig >/dev/null 2>&1 && [ "$nixos" -eq 0 ]; then
+    missing_libs=()
+    for lib in libdcgm.so.4 libnvidia-ml.so.1; do
+        if ! ldconfig -p 2>/dev/null | grep -q -- "$lib"; then
+            missing_libs+=("$lib")
+        fi
+    done
+    if [ "${#missing_libs[@]}" -gt 0 ]; then
+        printf '%sWARN%s: ldconfig does not list: %s\n' \
+            "$YELLOW" "$NC" "${missing_libs[*]}" >&2
+        echo "       If the daemon fails to start below, install NVIDIA DCGM and the driver." >&2
+        echo "       Proceeding anyway — daemon startup will surface the real error if libs are unreachable." >&2
+        echo >&2
+    fi
+fi
+
+info "Binary:   $BIN"
+info "Port:     $PORT"
+info "Budget:   ${SHUTDOWN_BUDGET_SECONDS}s shutdown, ${STARTUP_TIMEOUT_SECONDS}s startup"
+
+#─────────────────────────────────────────────────────────────────────────
+# Test 1 — SIGTERM
+#─────────────────────────────────────────────────────────────────────────
+
+info "=== Test 1: SIGTERM → clean shutdown ==="
+start_daemon
+stop_daemon_with_signal TERM
+
+#─────────────────────────────────────────────────────────────────────────
+# Test 2 — SIGINT
+#─────────────────────────────────────────────────────────────────────────
+
+info "=== Test 2: SIGINT → clean shutdown ==="
+start_daemon
+stop_daemon_with_signal INT
+
+#─────────────────────────────────────────────────────────────────────────
+# Test 3 — SIGHUP triggers reload, daemon stays up
+#─────────────────────────────────────────────────────────────────────────
+
+info "=== Test 3: SIGHUP → hot reload, daemon stays up ==="
+start_daemon
+info "Sending SIGHUP to pid=${DAEMON_PID}"
+kill -s HUP "$DAEMON_PID"
+# Give the reload a moment to complete.
+sleep 2
+if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+    fail "daemon died after SIGHUP (should hot-reload, not exit)"
+fi
+if ! curl -fsSL --max-time 5 "$METRICS_URL" >/dev/null 2>&1; then
+    fail "/metrics not responding after SIGHUP"
+fi
+pass "daemon survived SIGHUP and /metrics still responds"
+stop_daemon_with_signal TERM
+
+#─────────────────────────────────────────────────────────────────────────
+# Test 4 — Multiple SIGHUPs back-to-back
+#─────────────────────────────────────────────────────────────────────────
+
+info "=== Test 4: 3 × SIGHUP → all reloads complete ==="
+start_daemon
+for i in 1 2 3; do
+    info "SIGHUP #$i"
+    kill -s HUP "$DAEMON_PID"
+    sleep 1
+    if ! kill -0 "$DAEMON_PID" 2>/dev/null; then
+        fail "daemon died after SIGHUP #$i"
+    fi
+done
+if ! curl -fsSL --max-time 5 "$METRICS_URL" >/dev/null 2>&1; then
+    fail "/metrics not responding after 3 SIGHUPs"
+fi
+pass "daemon survived 3 SIGHUPs and /metrics still responds"
+stop_daemon_with_signal TERM
+
+#─────────────────────────────────────────────────────────────────────────
+# Summary
+#─────────────────────────────────────────────────────────────────────────
+
+echo
+info "All signal tests passed."


### PR DESCRIPTION
# Context architecture refactor — signal-cancellable root + docs + tests

Hi maintainers — while preparing the recent batch of small static-analysis fixes (PRs #681 through #694) we ended up reading a lot of the daemon's startup and shutdown paths, and we noticed an opportunity to tighten the context-handling architecture for the program as a whole. This PR proposes that change.

We understand this one is a little more complex than the mechanical security fixes in the earlier PRs. We operate `dcgm-exporter` in production on several thousand machines, many of them internet-facing. Our goal across this whole series has been to leave the tool in very good shape both from a security perspective and architecturally — this PR is the architectural half of that.

## TL;DR

A single, signal-cancellable root `context.Context` is created in `main()` via `signal.NotifyContext(SIGINT, SIGTERM)` and threaded through `app.RunContext` → `c.Context` → the daemon's startup chain → watchers / server / shutdown loop. `SIGHUP` keeps flowing through the existing `SignalSource` channel for hot reload — that semantic is preserved.

New contributor-facing doc (`docs/CONTEXTS.md`) explains the tree, the conventions, and how to test context-aware code. New table-driven unit test, new integration test, new black-box signal test, new `make test-signals` target.

## What changes

| File | Purpose |
| --- | --- |
| `cmd/dcgm-exporter/main.go` | `signal.NotifyContext(SIGINT, SIGTERM)` + `app.RunContext(ctx, …)`. |
| `pkg/cmd/app.go` | `action()` uses `c.Context` for `stdout.Capture`; `StartDCGMExporterWithSignalSource` derives `ctx` and `watcherCtx` from `c.Context`; shutdown loop is a `select` on both `sigSource.Signals()` and `ctx.Done()`. |
| `docs/CONTEXTS.md` (new) | Contributor-facing architecture doc — tree, signal split, conventions, testing recipe. Linked from `README.md`. |
| `pkg/cmd/app_test.go` | `TestActionUsesCliContext` — table-driven, 4 cases (positive, negative, boundary, corner). |
| `tests/integration/start_read_test.go` | `TestShutdownViaContextCancel` — drives shutdown via ctx cancel instead of SIGTERM, sibling to the existing `TestStartAndReadMetrics`. |
| `tests/signals/test_signals.sh` (new) | Black-box bash test — real binary, real signals, real `/metrics` scrapes. Four scenarios. |
| `tests/signals/README.md` (new) | Operator docs for the bash test. |
| `Makefile` | New `test-signals` target. |
| `README.md` | One-line link to `docs/CONTEXTS.md`. |

## Why this matters

Before this PR, the daemon had three independent shutdown / lifecycle signals that didn't fully agree:

1. The `urfave/cli` `c.Context` (today always `context.Background()` because `main` calls `app.Run`, not `app.RunContext`).
2. The `SignalSource` channel that delivers `SIGINT` / `SIGTERM` / `SIGHUP` to an explicit shutdown loop.
3. The `stop chan interface{}` consumed by `metricsServer.Run`.

Subsystems that respect `ctx` — gRPC calls in `PodMapper.listPods`, the DRA informer factory, `stdout.Capture` — got a context that was effectively never cancelled by anything except an explicit `watcherCancel()`, and several of them weren't even derived from `watcherCtx`. So a hung gRPC call during scrape, or a slow informer sync, wouldn't be interrupted by `SIGTERM` until it hit its own internal timeout.

After this PR, a SIGTERM cancels the root `ctx` *and* delivers a `SignalSource` event. Both paths converge on the same graceful shutdown — belt and suspenders. The latency win lands when future PRs thread `ctx` into `PodMapper.listPods` (we have a draft for that already; we'd like to land this one first so reviewers see the whole story).

## What this PR does NOT change

- `SIGHUP` still flows through `SignalSource` and triggers hot reload. We deliberately did **not** fold it into ctx cancellation — shutdown and reload are different events, and operators rely on `kill -HUP $(pidof dcgm-exporter)` for zero-downtime config changes. We explain this trade-off in `docs/CONTEXTS.md`.
- The `stop chan interface{}` in `metricsServer.Run(ctx, stop)` is untouched. With ctx now signal-cancellable, it's arguably redundant, but removing it is a wider API change best left to a follow-up so this PR stays scoped.
- `transformation.PodMapper.listPods` and `NewDRAResourceSliceManager` still create their own `context.Background()`-rooted contexts. Those are sites we'd like to fix in follow-up PRs (drafts ready). Today they at least benefit from the explicit `Stop()` paths.
- No changes to Go module dependencies, the build pipeline, the Helm chart, or the CI workflow.

## Acceptable `context.Background()` sites that remain

After this PR, the only `context.Background()` calls in production code are:

| Site | Why |
| --- | --- |
| `cmd/dcgm-exporter/main.go` | The root. `signal.NotifyContext(parent, …)` needs a parent; `context.Background()` is the canonical process root in Go. |
| `internal/pkg/devicewatcher/device_watcher.go:82,405` | Inside `Cleanup` / inline cleanup callback in `createGroup`. No caller ctx is in scope; `slog.LogAttrs` uses the ctx only for handler attribute extraction, not for cancellation. |

Documented in `docs/CONTEXTS.md` so future contributors don't need to re-derive the reasoning. golangci-lint `contextcheck` gates new offenders.

## Testing

Three layers, in increasing order of cost:

### 1. Unit test — `make test-main`

`TestActionUsesCliContext` in `pkg/cmd/app_test.go`. Table-driven, 4 cases:

- positive: fresh ctx, callback runs to completion → `nil` error
- negative: pre-cancelled ctx aborts immediately → `context.Canceled`
- boundary: ctx cancelled mid-callback → `context.Canceled`, propagation < workTime/2
- corner: deadline shorter than work → `context.DeadlineExceeded`, propagation < workTime/2

Runs under `-short`. No GPU needed. Passes locally in ~95 ms.

### 2. Integration test — `make test-integration`

`TestShutdownViaContextCancel` in `tests/integration/start_read_test.go`, sibling to the existing `TestStartAndReadMetrics`. Drives shutdown via ctx cancellation instead of `testSigs.SendSignal(SIGTERM)`. Asserts the daemon exits within 10 s (same budget as the existing SIGTERM test).

Needs a GPU + DCGM (same requirements as the existing integration tests).

### 3. Black-box behavioural test — `make test-signals`

New `tests/signals/test_signals.sh`. Runs the real binary, sends real signals, scrapes real `/metrics`. Four scenarios:

| Test | Signal | Expectation |
| --- | --- | --- |
| 1 | `SIGTERM` | Daemon exits within `SHUTDOWN_BUDGET_SECONDS` (default 5 s) |
| 2 | `SIGINT` | Daemon exits within budget |
| 3 | `SIGHUP` | Daemon performs hot reload, stays running, `/metrics` keeps responding |
| 4 | 3 × `SIGHUP` | Daemon survives three back-to-back reloads |

Auto-detects NixOS and prepends `/run/opengl-driver/lib` + the first `/nix/store/.../lib/libdcgm.so.4` to `LD_LIBRARY_PATH`, preserving any caller-set entries. Auto-bumps `PORT` (default 9499 — off the canonical 9400) up to 20 ports if something is already listening, so a running `dcgm-exporter.service` doesn't clash.

Verified locally on a NixOS host with DCGM 4.3.1. Sample output:

```
--- NixOS detected; auto-configuring LD_LIBRARY_PATH for DCGM/NVML
--- === Test 1: SIGTERM → clean shutdown ===
PASS: daemon exited within 1s after SIGTERM
--- === Test 2: SIGINT → clean shutdown ===
PASS: daemon exited within 1s after SIGINT
--- === Test 3: SIGHUP → hot reload, daemon stays up ===
PASS: daemon survived SIGHUP and /metrics still responds
PASS: daemon exited within 1s after SIGTERM
--- === Test 4: 3 × SIGHUP → all reloads complete ===
PASS: daemon survived 3 SIGHUPs and /metrics still responds
PASS: daemon exited within 1s after SIGTERM

--- All signal tests passed.
```

## What to look at first when reviewing

1. **`docs/CONTEXTS.md`** — start here. The propagation tree explains the rest of the diff.
2. **`pkg/cmd/app.go` shutdown loop** — the change from blocking `<-sigs` to `select { case <-sigs; case <-ctx.Done() }` is the subtlest behavioural difference. The `select` preserves the SIGHUP-continues-the-loop semantic; only SIGTERM/SIGINT/SIGQUIT and `ctx.Done()` `break shutdownLoop`.
3. **`cmd/dcgm-exporter/main.go`** — small and self-contained. The 5 added lines are the entire entry-point change.
4. **`tests/signals/test_signals.sh`** — black-box proof the whole thing works. Easy to run locally; we'd love a confirmation that it passes on your reference hardware too.

## Follow-up PRs we have queued

We'd like to send these only after this one is approved/merged so each PR stays small and the chain is reviewable:

- `transformation: thread ctx through PodMapper.listPods` — makes the gRPC call honour scrape cancellation.
- `transformation/dra: derive informer ctx from parent` — DRA informer factory inherits root cancellation.
- `cmd: drop stop chan redundancy` — `metricsServer.Run(ctx)` once everything else is ctx-driven.

We're happy to defer or revise any of these based on your feedback on this one.

## DCO

Single commit, DCO-signed via `git commit -s`.

Thanks for considering — happy to revise anything in this PR or split it differently if you'd prefer smaller pieces.
