### PR TITLE
cleanup: fix typos in test code + add _typos.toml

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,25 @@
+# Configuration for the `typos` spell-checker.
+# See https://github.com/crate-ci/typos for the schema.
+
+[default]
+# These are not typos — they are domain vocabulary and proper nouns
+# that the default `typos` dictionary mistakes for misspellings.
+extend-ignore-identifiers-re = [
+    # NVIDIA / DCGM hardware vernacular: "DBE" = "Double-Bit Error".
+    # Appears in DCGM SDK identifiers like DCGM_FR_DBE_VIOLATION.
+    "(?i)dbe",
+]
+
+[default.extend-words]
+# Hashicorp (company name) appears in third-party licence attributions.
+Hashi = "Hashi"
+
+[files]
+# Module pseudo-versions in go.mod embed git short-hashes that look
+# like misspellings (e.g. "lann/ps v0.0.0-20150810152359-62de8c46ede0"
+# triggers `ede` → `edge`). The hashes are content addresses and
+# cannot be edited.
+extend-exclude = [
+    "go.mod",
+    "go.sum",
+]

--- a/internal/pkg/collector/gpu_health_collector_test.go
+++ b/internal/pkg/collector/gpu_health_collector_test.go
@@ -53,7 +53,7 @@ func TestNewGPUHealthStatusCollector(t *testing.T) {
 			},
 		},
 		{
-			name: "returns no errors, whe collector is enabled",
+			name: "returns no errors, when collector is enabled",
 			counterList: []counters.Counter{
 				{
 					FieldName: "DCGM_EXP_GPU_HEALTH_STATUS",
@@ -196,13 +196,13 @@ func TestGPUHealthStatusCollector_GetMetrics_ErrorHandling(t *testing.T) {
 	type testCase struct {
 		name                 string
 		setDCGMproviderState func(*mockdcgm.MockDCGM)
-		asserResult          func(MetricsByCounter, error)
+		assertResult         func(MetricsByCounter, error)
 	}
 
 	testCases := []testCase{
 		{
 			name: "returns Metrics without errors",
-			asserResult: func(metrics MetricsByCounter, err error) {
+			assertResult: func(metrics MetricsByCounter, err error) {
 				require.NoError(t, err)
 				// We expect 1 metric: DCGM_EXP_GPU_HEALTH_STATUS
 				require.Len(t, metrics, 1)
@@ -233,7 +233,7 @@ func TestGPUHealthStatusCollector_GetMetrics_ErrorHandling(t *testing.T) {
 				mockDCGMProvider.EXPECT().HealthCheck(gomock.Any()).Return(dcgm.HealthResponse{},
 					errors.New("boom!"))
 			},
-			asserResult: func(metrics MetricsByCounter, err error) {
+			assertResult: func(metrics MetricsByCounter, err error) {
 				assert.Error(t, err)
 				assert.Empty(t, metrics)
 			},
@@ -243,7 +243,7 @@ func TestGPUHealthStatusCollector_GetMetrics_ErrorHandling(t *testing.T) {
 			setDCGMproviderState: func(mockDCGMProvider *mockdcgm.MockDCGM) {
 				mockDCGMProvider.EXPECT().GetGroupInfo(gomock.Any()).Return(nil, errors.New("boom!")).AnyTimes()
 			},
-			asserResult: func(metrics MetricsByCounter, err error) {
+			assertResult: func(metrics MetricsByCounter, err error) {
 				assert.Error(t, err)
 				assert.Empty(t, metrics)
 			},
@@ -254,7 +254,7 @@ func TestGPUHealthStatusCollector_GetMetrics_ErrorHandling(t *testing.T) {
 				mockDCGMProvider.EXPECT().EntityGetLatestValues(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return([]dcgm.FieldValue_v1{}, errors.New("boom!")).AnyTimes()
 			},
-			asserResult: func(metrics MetricsByCounter, err error) {
+			assertResult: func(metrics MetricsByCounter, err error) {
 				assert.Error(t, err)
 				assert.Empty(t, metrics)
 			},
@@ -295,7 +295,7 @@ func TestGPUHealthStatusCollector_GetMetrics_ErrorHandling(t *testing.T) {
 
 			metrics, err := collector.GetMetrics()
 
-			tc.asserResult(metrics, err)
+			tc.assertResult(metrics, err)
 
 			ctrl.Finish() // This will finish the current controller
 		})

--- a/internal/pkg/integration_test/collector_test.go
+++ b/internal/pkg/integration_test/collector_test.go
@@ -1134,7 +1134,7 @@ func TestGPUCollector_GetMetrics(t *testing.T) {
 	numGPUs, err = dcgmprovider.Client().GetAllDeviceCount()
 	require.NoError(t, err)
 
-	intputCounters := []counters.Counter{
+	inputCounters := []counters.Counter{
 		{
 			FieldID:   100,
 			FieldName: "DCGM_FI_DEV_SM_CLOCK",
@@ -1143,7 +1143,7 @@ func TestGPUCollector_GetMetrics(t *testing.T) {
 		},
 	}
 
-	deviceWatchListManager := devicewatchlistmanager.NewWatchListManager(intputCounters, config)
+	deviceWatchListManager := devicewatchlistmanager.NewWatchListManager(inputCounters, config)
 	err = deviceWatchListManager.CreateEntityWatchList(dcgm.FE_GPU, deviceWatcher,
 		int64(config.CollectInterval))
 	require.NoError(t, err)
@@ -1155,7 +1155,7 @@ func TestGPUCollector_GetMetrics(t *testing.T) {
 	gpuItem, exists := deviceWatchListManager.EntityWatchList(dcgm.FE_GPU)
 	require.True(t, exists)
 
-	c, err := collector.NewDCGMCollector(intputCounters, "", config, gpuItem)
+	c, err := collector.NewDCGMCollector(inputCounters, "", config, gpuItem)
 	require.NoError(t, err)
 
 	defer c.Cleanup()
@@ -1164,7 +1164,7 @@ func TestGPUCollector_GetMetrics(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, out, 1)
 
-	values := out[intputCounters[0]]
+	values := out[inputCounters[0]]
 
 	require.Equal(t, numGPUs, uint(len(values)))
 }

--- a/internal/pkg/prerequisites/dcgmlib_rule_test.go
+++ b/internal/pkg/prerequisites/dcgmlib_rule_test.go
@@ -129,7 +129,7 @@ func Test_dcgmLibExistsRule_Validate(t *testing.T) {
 			},
 		},
 		{
-			Name: "returns error when library architecture missmatch",
+			Name: "returns error when library architecture mismatch",
 			ExecMockExpectations: func(ctrl *gomock.Controller, mockExec *mockexec.MockExec) {
 				output := `1211 libs found in cache '/etc/ld.so.cache'
 				libdcgm.so.4 (libc6,x86-64) => /lib/x86_64-linux-gnu/libdcgm.so.4

--- a/internal/pkg/testutils/test_utils.go
+++ b/internal/pkg/testutils/test_utils.go
@@ -166,7 +166,7 @@ func GetStructPrivateFieldValue[T any](t *testing.T, v any, fieldName string) T 
 	}
 
 	if value.Kind() != reflect.Struct {
-		t.Errorf("The type %s is not stuct", value.Type())
+		t.Errorf("The type %s is not struct", value.Type())
 		return result
 	}
 


### PR DESCRIPTION
# cleanup: fix typos in test code + add `_typos.toml`

While running the [`typos`](https://github.com/crate-ci/typos) spell-checker we found a handful of misspellings in test code. This PR fixes them and adds a small `_typos.toml` configuration that silences the recurring false positives so future runs surface only real findings.

After this PR, `typos .` exits 0 from the repo root.

## Code fixes

| File | Change |
| --- | --- |
| `internal/pkg/prerequisites/dcgmlib_rule_test.go:132` | test case name: `missmatch` → `mismatch` |
| `internal/pkg/testutils/test_utils.go:169` | error message: `stuct` → `struct` |
| `internal/pkg/collector/gpu_health_collector_test.go:56` | test case name: `whe` → `when` |
| `internal/pkg/collector/gpu_health_collector_test.go` (×6) | struct field + uses: `asserResult` → `assertResult` |
| `internal/pkg/integration_test/collector_test.go` (×4) | variable: `intputCounters` → `inputCounters` |

No behaviour change — all touched identifiers are package-local to test files. `go build`, `go vet`, and `gofmt` are clean.

## `_typos.toml`

Three deliberate suppressions, each commented in the file:

- **`DBE` / `dbe`** — "Double-Bit Error" in NVIDIA GPU vernacular. Matches DCGM SDK identifiers like `DCGM_FR_DBE_VIOLATION`. Domain term, not a misspelling.
- **`Hashi`** — appears in third-party licence attribution for Hashicorp libraries (errwrap, multierror, go-lru). Proper noun.
- **`go.mod` / `go.sum`** excluded entirely — module pseudo-versions embed git short-hashes (e.g. `lann/ps v0.0.0-20150810152359-62de8c46ede0`) that trip the dictionary. The hashes are content addresses and cannot be edited.

The flake's `nix run .#lint-typos` (and any future CI job that runs `typos`) will now be a clean signal rather than 45 entries of noise.
