### PR TITLE
Use local hostname when remote hostengine is on loopback

### DIFF
--- a/internal/pkg/hostname/hostname.go
+++ b/internal/pkg/hostname/hostname.go
@@ -18,6 +18,7 @@ package hostname
 
 import (
 	"net"
+	"strings"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	osinterface "github.com/NVIDIA/dcgm-exporter/internal/pkg/os"
@@ -46,7 +47,32 @@ func parseRemoteHostname(config *appconfig.Config) (string, error) {
 		// In that case, use the appconfig.RemoteHEInfo as is
 		host = config.RemoteHEInfo
 	}
+
+	// When the remote hostengine runs on the local node (for example a non-default
+	// port on "localhost"), the extracted host ("localhost", "127.0.0.1", "::1", ...)
+	// is not a useful label value and would make metrics impossible to filter by node.
+	// Fall back to the local hostname in that case.
+	if isLoopbackHost(host) {
+		return getLocalHostname()
+	}
+
 	return host, nil
+}
+
+// isLoopbackHost reports whether host refers to the local node, i.e. "localhost"
+// or any loopback IP address (127.0.0.0/8, ::1). Surrounding brackets on an IPv6
+// literal (for example "[::1]") are tolerated.
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 func getLocalHostname() (string, error) {

--- a/internal/pkg/hostname/hostname_test.go
+++ b/internal/pkg/hostname/hostname_test.go
@@ -29,6 +29,21 @@ import (
 	osinterface "github.com/NVIDIA/dcgm-exporter/internal/pkg/os"
 )
 
+// mockLocalHostname returns a hook that makes getLocalHostname resolve to name
+// via os.Hostname() (with NODE_NAME unset).
+func mockLocalHostname(t *testing.T, name string) func() func() {
+	return func() func() {
+		ctrl := gomock.NewController(t)
+		m := osmock.NewMockOS(ctrl)
+		m.EXPECT().Getenv(gomock.Eq("NODE_NAME"))
+		m.EXPECT().Hostname().Return(name, nil).AnyTimes()
+		os = m
+		return func() {
+			os = osinterface.RealOS{}
+		}
+	}
+}
+
 func TestGetHostname(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -106,12 +121,30 @@ func TestGetHostname(t *testing.T) {
 			want: "example.com",
 		},
 		{
-			name: "When appconfig.UseRemoteHE is true and hostname is IP address",
+			name: "When appconfig.UseRemoteHE is true and hostname is public IP address",
+			config: &appconfig.Config{
+				UseRemoteHE:  true,
+				RemoteHEInfo: "192.168.1.1",
+			},
+			want: "192.168.1.1",
+		},
+		{
+			name: "When appconfig.UseRemoteHE is true and hostname is loopback IP address",
 			config: &appconfig.Config{
 				UseRemoteHE:  true,
 				RemoteHEInfo: "127.0.0.1",
 			},
-			want: "127.0.0.1",
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
+		},
+		{
+			name: "When appconfig.UseRemoteHE is true and remote is loopback IP with custom port",
+			config: &appconfig.Config{
+				UseRemoteHE:  true,
+				RemoteHEInfo: "127.0.0.1:5556",
+			},
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
 		},
 		{
 			name: "When appconfig.UseRemoteHE is true, kubernetes is true, and hostname is localhost",
@@ -133,12 +166,30 @@ func TestGetHostname(t *testing.T) {
 			want: "test-hostname",
 		},
 		{
-			name: "When appconfig.UseRemoteHE is true and remote hostname is name",
+			name: "When appconfig.UseRemoteHE is true and remote is localhost with custom port",
 			config: &appconfig.Config{
 				UseRemoteHE:  true,
 				RemoteHEInfo: "localhost:5555",
 			},
-			want: "localhost",
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
+		},
+		{
+			name: "When appconfig.UseRemoteHE is true and remote is localhost using NODE_NAME",
+			config: &appconfig.Config{
+				UseRemoteHE:  true,
+				RemoteHEInfo: "localhost:5556",
+			},
+			hook: func() func() {
+				ctrl := gomock.NewController(t)
+				m := osmock.NewMockOS(ctrl)
+				m.EXPECT().Getenv(gomock.Eq("NODE_NAME")).Return("node-from-env")
+				os = m
+				return func() {
+					os = osinterface.RealOS{}
+				}
+			},
+			want: "node-from-env",
 		},
 		{
 			name: "When appconfig.UseRemoteHE is true and remote address is IPv6 loopback with port",
@@ -146,7 +197,8 @@ func TestGetHostname(t *testing.T) {
 				UseRemoteHE:  true,
 				RemoteHEInfo: "[::1]:5555",
 			},
-			want: "::1",
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
 		},
 		{
 			name: "When appconfig.UseRemoteHE is true and remote address is full IPv6 with port",
@@ -165,20 +217,22 @@ func TestGetHostname(t *testing.T) {
 			want: "::",
 		},
 		{
-			name: "When appconfig.UseRemoteHE is true and remote address is IPv6 without port",
+			name: "When appconfig.UseRemoteHE is true and remote address is IPv6 loopback without port",
 			config: &appconfig.Config{
 				UseRemoteHE:  true,
 				RemoteHEInfo: "[::1]",
 			},
-			want: "[::1]",
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
 		},
 		{
-			name: "When appconfig.UseRemoteHE is true and remote address is bare IPv6 without brackets or port",
+			name: "When appconfig.UseRemoteHE is true and remote address is bare IPv6 loopback without brackets or port",
 			config: &appconfig.Config{
 				UseRemoteHE:  true,
 				RemoteHEInfo: "::1",
 			},
-			want: "::1",
+			hook: mockLocalHostname(t, "test-hostname"),
+			want: "test-hostname",
 		},
 		{
 			name: "When appconfig.UseRemoteHE is true and remote address is empty",


### PR DESCRIPTION
  In v4 the `hostname` label is derived from the host portion of the remote hostengine address passed via `-r` / `DCGM_REMOTE_HOSTENGINE_INFO`. When the hostengine runs on the local node but on a non-default port (for example
  `localhost:5556` or `127.0.0.1:5556`), the label ends up being `localhost` / `127.0.0.1`. That makes it impossible to distinguish or filter metrics by node in Grafana dashboards.

  This change detects loopback remote addresses and falls back to the local hostname, matching the behavior the exporter already uses for the Kubernetes path.

  Loopback detection covers:

  - `localhost` (case-insensitive)
  - IPv4 loopback `127.0.0.0/8`
  - IPv6 loopback `::1`
  - bracketed and port-suffixed forms (`[::1]:5555`, `127.0.0.1:5556`, ...)

  Non-loopback hosts (`example.com`, public IPv4/IPv6, the unspecified address `::`) are unaffected and still used verbatim. The fallback honors `NODE_NAME` first, then `os.Hostname()`, identical to the existing local path.

Closes #572