### PR TITLE
Fall back to metrics file instead of crashing on ConfigMap read failure

### DIFF
--- a/internal/pkg/counters/counter_config.go
+++ b/internal/pkg/counters/counter_config.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
-	"github.com/NVIDIA/dcgm-exporter/internal/pkg/kubeclient"
 )
 
 func GetCounterSet(ctx context.Context, c *appconfig.Config) (*CounterSet, error) {
@@ -42,15 +41,18 @@ func GetCounterSet(ctx context.Context, c *appconfig.Config) (*CounterSet, error
 
 	if c.ConfigMapData != undefinedConfigMapData {
 		var client kubernetes.Interface
-		client, err = kubeclient.GetKubeClient()
+		client, err = getKubeClient()
 		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
-		}
-		records, err = readConfigMap(ctx, client, c)
-		if err != nil {
-			slog.Error(err.Error())
-			os.Exit(1)
+			slog.Warn("Failed to create Kubernetes client to read the counters ConfigMap; "+
+				"falling back to the metrics file. In Kubernetes this usually means the pod has no "+
+				"mounted ServiceAccount token (/var/run/secrets/kubernetes.io/serviceaccount/token); "+
+				"ensure a ServiceAccount is configured and automountServiceAccountToken is enabled.",
+				"configMap", c.ConfigMapData,
+				"error", err)
+		} else if records, err = readConfigMap(ctx, client, c); err != nil {
+			slog.Warn("Failed to read the counters ConfigMap; falling back to the metrics file.",
+				"configMap", c.ConfigMapData,
+				"error", err)
 		}
 	} else {
 		err = fmt.Errorf("no configmap data specified")

--- a/internal/pkg/counters/counter_config_test.go
+++ b/internal/pkg/counters/counter_config_test.go
@@ -18,6 +18,7 @@ package counters
 
 import (
 	"context"
+	"errors"
 	stdos "os"
 	"testing"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
@@ -112,6 +114,85 @@ func TestInvalidConfigMapNamespace(t *testing.T) {
 	records, err := readConfigMap(context.Background(), clientset, &c)
 	require.Error(t, err, "Should have returned an error")
 	require.Empty(t, records, "Should have no records")
+}
+
+// overrideKubeClient swaps the package-level getKubeClient for the duration of a
+// test and returns a function that restores the original.
+func overrideKubeClient(fn func() (kubernetes.Interface, error)) func() {
+	prev := getKubeClient
+	getKubeClient = fn
+	return func() { getKubeClient = prev }
+}
+
+// writeCountersFile writes content to a temp file and returns its path.
+func writeCountersFile(t *testing.T, content string) string {
+	t.Helper()
+	tmpFile, err := stdos.CreateTemp(t.TempDir(), "counters-*.csv")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	return tmpFile.Name()
+}
+
+// When a ConfigMap is configured but no Kubernetes client can be created (e.g. the
+// ServiceAccount token is not mounted), GetCounterSet must fall back to the metrics
+// file instead of crashing the process. Regression test for issue #624.
+func TestGetCounterSetFallsBackToFileWhenKubeClientUnavailable(t *testing.T) {
+	defer overrideKubeClient(func() (kubernetes.Interface, error) {
+		return nil, errors.New("open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory")
+	})()
+
+	c := appconfig.Config{
+		ConfigMapData:  "default:configmap1",
+		CollectorsFile: writeCountersFile(t, "DCGM_FI_DEV_GPU_TEMP, gauge, temperature\n"),
+	}
+
+	cc, err := GetCounterSet(context.Background(), &c)
+	require.NoError(t, err)
+	require.Len(t, cc.DCGMCounters, 1)
+}
+
+// When the ConfigMap cannot be read (e.g. it does not exist), GetCounterSet must
+// also fall back to the metrics file rather than crash.
+func TestGetCounterSetFallsBackToFileWhenConfigMapMissing(t *testing.T) {
+	clientset := fake.NewSimpleClientset()
+	defer overrideKubeClient(func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})()
+
+	c := appconfig.Config{
+		ConfigMapData:  "default:configmap1",
+		CollectorsFile: writeCountersFile(t, "DCGM_FI_DEV_GPU_TEMP, gauge, temperature\n"),
+	}
+
+	cc, err := GetCounterSet(context.Background(), &c)
+	require.NoError(t, err)
+	require.Len(t, cc.DCGMCounters, 1)
+}
+
+// When the ConfigMap is available, GetCounterSet must use it and not the metrics file.
+func TestGetCounterSetUsesConfigMapWhenAvailable(t *testing.T) {
+	clientset := fake.NewSimpleClientset(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "configmap1",
+			Namespace: "default",
+		},
+		Data: map[string]string{"metrics": "DCGM_FI_DEV_GPU_TEMP, gauge, temperature"},
+	})
+	defer overrideKubeClient(func() (kubernetes.Interface, error) {
+		return clientset, nil
+	})()
+
+	c := appconfig.Config{
+		ConfigMapData:  "default:configmap1",
+		CollectorsFile: writeCountersFile(t, "DCGM_FI_DEV_SM_CLOCK, gauge, sm clock\nDCGM_FI_DEV_MEM_CLOCK, gauge, mem clock\n"),
+	}
+
+	cc, err := GetCounterSet(context.Background(), &c)
+	require.NoError(t, err)
+	// One counter from the ConfigMap, proving the file (which has two) was not used.
+	require.Len(t, cc.DCGMCounters, 1)
 }
 
 func TestExtractCounters(t *testing.T) {

--- a/internal/pkg/counters/variables.go
+++ b/internal/pkg/counters/variables.go
@@ -16,9 +16,18 @@
 
 package counters
 
-import osinterface "github.com/NVIDIA/dcgm-exporter/internal/pkg/os"
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/kubeclient"
+	osinterface "github.com/NVIDIA/dcgm-exporter/internal/pkg/os"
+)
 
 var os osinterface.OS = osinterface.RealOS{}
+
+// getKubeClient returns an in-cluster Kubernetes client. It is declared as a
+// variable so tests can override it.
+var getKubeClient func() (kubernetes.Interface, error) = kubeclient.GetKubeClient
 
 var promMetricType = map[string]bool{
 	"gauge":     true,


### PR DESCRIPTION
When a counters ConfigMap is configured (the default for the Helm chart), `counters.GetCounterSet` creates an in-cluster Kubernetes client and called `os.Exit(1)` if either the client creation or the ConfigMap read failed.

In a pod where the ServiceAccount token is not mounted, this turns a recoverable condition into a `CrashLoopBackOff`, with only the raw error in the logs:

```
level=INFO msg="Collecting DCP Metrics"
level=ERROR msg="open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory"
```

The exit happens even though `GetCounterSet` already has a fallback-to-metrics-file path: the `os.Exit(1)` short-circuits it before it can run.

**Behavior change**

- ConfigMap configured but no kube client (e.g. no SA token): warn + fall back to the metrics file, exporter starts and serves metrics (using default counters) instead of crash-looping.
- ConfigMap configured but unreadable/missing: same graceful fallback.
- ConfigMap available: unchanged, counters are read from the ConfigMap.
- No ConfigMap configured: unchanged.

Closes #624
