### PR TITLE
Drop direct dependency on archived github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/mittwald/go-helm-client v0.12.19
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.67.5
 	github.com/prometheus/exporter-toolkit v0.16.0
@@ -122,6 +121,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/tests/e2e/internal/framework/kube.go
+++ b/tests/e2e/internal/framework/kube.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/pkg/errors"
 	"k8s.io/client-go/transport/spdy"
 
 	"k8s.io/client-go/tools/portforward"
@@ -323,7 +322,7 @@ func (c *KubeClient) PortForward(
 
 	select {
 	case err = <-errCh:
-		return -1, errors.Wrap(err, "port forwarding failed")
+		return -1, fmt.Errorf("port forwarding failed: %w", err)
 	case <-fw.Ready:
 	}
 


### PR DESCRIPTION
github.com/pkg/errors was archived by its author in 2021. It was used in a single place (tests/e2e/internal/framework/kube.go) via errors.Wrap. Replace it with the standard library equivalent fmt.Errorf("...: %w", err), which the same file already uses elsewhere, and run go mod tidy.

The package now only remains as an indirect dependency pulled in transitively by helm.sh/helm/v3 (via mittwald/go-helm-client), which is outside this repository's control.

Closes #526