### PR TITLE
fix: skip GPM/DCP metrics on fractional vGPU guests

### DIFF
--- a/internal/pkg/profiling/gpm.go
+++ b/internal/pkg/profiling/gpm.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package profiling validates runtime support for DCGM profiling (DCP/GPM) metrics.
+package profiling
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
+)
+
+const gpmProbeSampleInterval = 500 * time.Millisecond
+
+// VirtualizationModeBlocksGPM reports whether the NVML virtualization mode prevents
+// collection of GPM-backed DCGM_FI_PROF_* metrics. Fractional vGPU guests (for example
+// GKE G4 g4-standard-6/12/24 shapes) run in vGPU mode and cannot provide GPM samples.
+func VirtualizationModeBlocksGPM(mode nvml.GpuVirtualizationMode) bool {
+	switch mode {
+	case nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateGPMSupport checks whether GPM profiling metrics can be collected on all
+// visible GPUs. When validation fails, callers should disable DCP metric collection
+// while continuing to export standard NVML-backed DCGM metrics.
+func ValidateGPMSupport() (bool, string) {
+	gpuCount, err := dcgmprovider.Client().GetAllDeviceCount()
+	if err != nil {
+		return false, fmt.Sprintf("failed to get GPU count: %v", err)
+	}
+	if gpuCount == 0 {
+		return false, "no GPUs found"
+	}
+
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		slog.Warn("Skipping GPM validation because NVML could not be initialized",
+			slog.String("error", nvml.ErrorString(ret)))
+		return true, ""
+	}
+	defer nvml.Shutdown()
+
+	for gpuID := uint(0); gpuID < gpuCount; gpuID++ {
+		gpuInfo, err := dcgmprovider.Client().GetDeviceInfo(gpuID)
+		if err != nil {
+			return false, fmt.Sprintf("failed to get device info for GPU %d: %v", gpuID, err)
+		}
+
+		device, ret := nvml.DeviceGetHandleByUUID(gpuInfo.UUID)
+		if ret != nvml.SUCCESS {
+			return false, fmt.Sprintf("failed to get NVML handle for GPU %s: %s", gpuInfo.UUID, nvml.ErrorString(ret))
+		}
+
+		if mode, ret := device.GetVirtualizationMode(); ret == nvml.SUCCESS {
+			if VirtualizationModeBlocksGPM(mode) {
+				return false, fmt.Sprintf(
+					"GPU %s is in vGPU virtualization mode; GPM profiling metrics are not available",
+					gpuInfo.UUID,
+				)
+			}
+		} else {
+			slog.Debug("Could not query GPU virtualization mode",
+				slog.String("gpu_uuid", gpuInfo.UUID),
+				slog.String("error", nvml.ErrorString(ret)))
+		}
+
+		gpmSupport, ret := device.GpmQueryDeviceSupport()
+		if ret != nvml.SUCCESS {
+			return false, fmt.Sprintf("GPU %s GPM support query failed: %s", gpuInfo.UUID, nvml.ErrorString(ret))
+		}
+		if gpmSupport.IsSupportedDevice == 0 {
+			return false, fmt.Sprintf("GPU %s does not support GPM", gpuInfo.UUID)
+		}
+
+		if !probeGPMSample(device) {
+			return false, fmt.Sprintf("GPU %s failed GPM sample probe", gpuInfo.UUID)
+		}
+	}
+
+	return true, ""
+}
+
+func probeGPMSample(device nvml.Device) bool {
+	sample1, ret := nvml.GpmSampleAlloc()
+	if ret != nvml.SUCCESS {
+		slog.Debug("GPM sample allocation failed", slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+	defer func() {
+		if freeRet := nvml.GpmSampleFree(sample1); freeRet != nvml.SUCCESS {
+			slog.Debug("GPM sample free failed", slog.String("error", nvml.ErrorString(freeRet)))
+		}
+	}()
+
+	sample2, ret := nvml.GpmSampleAlloc()
+	if ret != nvml.SUCCESS {
+		slog.Debug("GPM sample allocation failed", slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+	defer func() {
+		if freeRet := nvml.GpmSampleFree(sample2); freeRet != nvml.SUCCESS {
+			slog.Debug("GPM sample free failed", slog.String("error", nvml.ErrorString(freeRet)))
+		}
+	}()
+
+	if ret := device.GpmSampleGet(sample1); ret != nvml.SUCCESS {
+		slog.Debug("First GPM sample failed", slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+
+	time.Sleep(gpmProbeSampleInterval)
+
+	if ret := device.GpmSampleGet(sample2); ret != nvml.SUCCESS {
+		slog.Debug("Second GPM sample failed", slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+
+	metricsGet := nvml.GpmMetricsGetType{
+		Sample1:    sample1,
+		Sample2:    sample2,
+		NumMetrics: 1,
+	}
+	metricsGet.Metrics[0].MetricId = uint32(nvml.GPM_METRIC_GRAPHICS_UTIL)
+
+	if ret := nvml.GpmMetricsGet(&metricsGet); ret != nvml.SUCCESS {
+		slog.Debug("GPM metrics query failed", slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+	if metricsGet.Metrics[0].NvmlReturn != uint32(nvml.SUCCESS) {
+		slog.Debug("GPM metric returned NVML error", slog.Uint64("nvml_return", uint64(metricsGet.Metrics[0].NvmlReturn)))
+		return false
+	}
+
+	return true
+}

--- a/internal/pkg/profiling/gpm.go
+++ b/internal/pkg/profiling/gpm.go
@@ -30,6 +30,23 @@ import (
 
 const gpmProbeSampleInterval = 500 * time.Millisecond
 
+// gpmDeviceChecker abstracts the NVML operations required to determine a GPU's GPM
+// status. It is a package-level seam so tests can substitute a fake implementation
+// without a real NVML library or GPU.
+type gpmDeviceChecker interface {
+	// init prepares the checker. It returns false when NVML is unavailable, in which
+	// case GPM validation is skipped and existing behavior is preserved.
+	init() bool
+	// shutdown releases any resources acquired by init.
+	shutdown()
+	// statusForUUID returns the GPM status of the GPU identified by uuid.
+	statusForUUID(uuid string) gpuGPMStatus
+}
+
+// deviceChecker is the checker used by ValidateGPMSupport. It defaults to the real
+// NVML-backed implementation and is overridden in tests.
+var deviceChecker gpmDeviceChecker = nvmlGPMChecker{}
+
 // gpuGPMStatus captures the GPM capability of a single GPU as observed at runtime.
 type gpuGPMStatus int
 
@@ -82,17 +99,23 @@ func ValidateGPMSupport(config *appconfig.Config) (bool, string) {
 		return false, ""
 	}
 
-	ret := nvml.Init()
-	if ret != nvml.SUCCESS {
-		slog.Warn("Skipping GPM validation because NVML could not be initialized",
-			slog.String("error", nvml.ErrorString(ret)))
+	if !deviceChecker.init() {
+		// NVML unavailable; keep existing behavior rather than disabling.
 		return false, ""
 	}
-	defer nvml.Shutdown()
+	defer deviceChecker.shutdown()
 
 	statuses := make([]gpuGPMStatus, 0, gpuCount)
 	for gpuID := uint(0); gpuID < gpuCount; gpuID++ {
-		statuses = append(statuses, gpmStatusForGPU(gpuID))
+		gpuInfo, err := dcgmprovider.Client().GetDeviceInfo(gpuID)
+		if err != nil {
+			slog.Debug("GPM validation: could not get device info",
+				slog.Uint64("gpu_id", uint64(gpuID)),
+				slog.String("error", err.Error()))
+			statuses = append(statuses, gpmUnknown)
+			continue
+		}
+		statuses = append(statuses, deviceChecker.statusForUUID(gpuInfo.UUID))
 	}
 
 	disableDCP, reason := decideDCPFromGPMStatuses(statuses)
@@ -111,20 +134,31 @@ func ValidateGPMSupport(config *appconfig.Config) (bool, string) {
 	return disableDCP, reason
 }
 
-// gpmStatusForGPU determines the GPM status of a single GPU using NVML.
-func gpmStatusForGPU(gpuID uint) gpuGPMStatus {
-	gpuInfo, err := dcgmprovider.Client().GetDeviceInfo(gpuID)
-	if err != nil {
-		slog.Debug("GPM validation: could not get device info",
-			slog.Uint64("gpu_id", uint64(gpuID)),
-			slog.String("error", err.Error()))
-		return gpmUnknown
-	}
+// nvmlGPMChecker is the production gpmDeviceChecker backed by the NVML library.
+type nvmlGPMChecker struct{}
 
-	device, ret := nvml.DeviceGetHandleByUUID(gpuInfo.UUID)
+func (nvmlGPMChecker) init() bool {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		slog.Warn("Skipping GPM validation because NVML could not be initialized",
+			slog.String("error", nvml.ErrorString(ret)))
+		return false
+	}
+	return true
+}
+
+func (nvmlGPMChecker) shutdown() {
+	if ret := nvml.Shutdown(); ret != nvml.SUCCESS {
+		slog.Debug("NVML shutdown after GPM validation failed",
+			slog.String("error", nvml.ErrorString(ret)))
+	}
+}
+
+func (nvmlGPMChecker) statusForUUID(uuid string) gpuGPMStatus {
+	device, ret := nvml.DeviceGetHandleByUUID(uuid)
 	if ret != nvml.SUCCESS {
 		slog.Debug("GPM validation: could not get NVML handle",
-			slog.String("gpu_uuid", gpuInfo.UUID),
+			slog.String("gpu_uuid", uuid),
 			slog.String("error", nvml.ErrorString(ret)))
 		return gpmUnknown
 	}
@@ -132,7 +166,7 @@ func gpmStatusForGPU(gpuID uint) gpuGPMStatus {
 	gpmSupport, ret := device.GpmQueryDeviceSupport()
 	if ret != nvml.SUCCESS {
 		slog.Debug("GPM validation: GPM support query failed",
-			slog.String("gpu_uuid", gpuInfo.UUID),
+			slog.String("gpu_uuid", uuid),
 			slog.String("error", nvml.ErrorString(ret)))
 		return gpmUnknown
 	}

--- a/internal/pkg/profiling/gpm.go
+++ b/internal/pkg/profiling/gpm.go
@@ -24,83 +24,160 @@ import (
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
 )
 
 const gpmProbeSampleInterval = 500 * time.Millisecond
 
-// VirtualizationModeBlocksGPM reports whether the NVML virtualization mode prevents
-// collection of GPM-backed DCGM_FI_PROF_* metrics. Fractional vGPU guests (for example
-// GKE G4 g4-standard-6/12/24 shapes) run in vGPU mode and cannot provide GPM samples.
-func VirtualizationModeBlocksGPM(mode nvml.GpuVirtualizationMode) bool {
-	switch mode {
-	case nvml.GPU_VIRTUALIZATION_MODE_VGPU, nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU:
-		return true
-	default:
-		return false
-	}
-}
+// gpuGPMStatus captures the GPM capability of a single GPU as observed at runtime.
+type gpuGPMStatus int
 
-// ValidateGPMSupport checks whether GPM profiling metrics can be collected on all
-// visible GPUs. When validation fails, callers should disable DCP metric collection
-// while continuing to export standard NVML-backed DCGM metrics.
-func ValidateGPMSupport() (bool, string) {
+const (
+	// gpmUnknown means GPM capability could not be determined (for example an NVML
+	// handle or query error). Such GPUs are ignored by the DCP decision so a transient
+	// lookup failure never disables profiling on its own.
+	gpmUnknown gpuGPMStatus = iota
+	// gpmNotApplicable means the GPU does not use GPM. Its DCGM_FI_PROF_* fields are
+	// served by the DCGM profiling module (DCP), not GPM (for example pre-Hopper GPUs
+	// such as the A100), so GPM validation must not disable profiling for it.
+	gpmNotApplicable
+	// gpmHealthy means the GPU supports GPM and a live sample probe succeeded.
+	gpmHealthy
+	// gpmBroken means the GPU advertises GPM support but a live sample probe failed.
+	// Fractional vGPU guests (for example GKE G4 g4-standard-6/12/24 shapes) exhibit
+	// this and trigger the repeated "-14 from m_gpmManager.GetLatestSample" error
+	// loop described in issue #661.
+	gpmBroken
+)
+
+// ValidateGPMSupport inspects every visible GPU and decides whether DCP/profiling
+// metric collection should be disabled for this cycle. It returns (true, reason) only
+// when disabling profiling is required to stop the GPM error loop and no GPU is able
+// to produce profiling metrics.
+//
+// The decision is intentionally conservative to avoid removing profiling from GPUs
+// that still support it:
+//   - Remote hostengine deployments are trusted, because local NVML cannot describe
+//     GPUs owned by a remote DCGM host.
+//   - GPUs that do not use GPM are left untouched; their profiling flows through the
+//     DCGM profiling module and is unaffected by GPM sample availability.
+//   - Profiling is disabled globally only when at least one GPM-capable GPU fails a
+//     live probe AND no other GPU (healthy GPM or non-GPM) can serve profiling.
+func ValidateGPMSupport(config *appconfig.Config) (bool, string) {
+	// Remote hostengine: GPU UUIDs come from the remote host and cannot be resolved
+	// through the local NVML library, so trust DCGM's capability result instead.
+	if config != nil && config.UseRemoteHE {
+		return false, ""
+	}
+
 	gpuCount, err := dcgmprovider.Client().GetAllDeviceCount()
 	if err != nil {
-		return false, fmt.Sprintf("failed to get GPU count: %v", err)
+		// Unable to enumerate GPUs; keep existing behavior rather than disabling.
+		slog.Debug("Skipping GPM validation: could not get GPU count",
+			slog.String("error", err.Error()))
+		return false, ""
 	}
 	if gpuCount == 0 {
-		return false, "no GPUs found"
+		return false, ""
 	}
 
 	ret := nvml.Init()
 	if ret != nvml.SUCCESS {
 		slog.Warn("Skipping GPM validation because NVML could not be initialized",
 			slog.String("error", nvml.ErrorString(ret)))
-		return true, ""
+		return false, ""
 	}
 	defer nvml.Shutdown()
 
+	statuses := make([]gpuGPMStatus, 0, gpuCount)
 	for gpuID := uint(0); gpuID < gpuCount; gpuID++ {
-		gpuInfo, err := dcgmprovider.Client().GetDeviceInfo(gpuID)
-		if err != nil {
-			return false, fmt.Sprintf("failed to get device info for GPU %d: %v", gpuID, err)
-		}
+		statuses = append(statuses, gpmStatusForGPU(gpuID))
+	}
 
-		device, ret := nvml.DeviceGetHandleByUUID(gpuInfo.UUID)
-		if ret != nvml.SUCCESS {
-			return false, fmt.Sprintf("failed to get NVML handle for GPU %s: %s", gpuInfo.UUID, nvml.ErrorString(ret))
-		}
+	disableDCP, reason := decideDCPFromGPMStatuses(statuses)
 
-		if mode, ret := device.GetVirtualizationMode(); ret == nvml.SUCCESS {
-			if VirtualizationModeBlocksGPM(mode) {
-				return false, fmt.Sprintf(
-					"GPU %s is in vGPU virtualization mode; GPM profiling metrics are not available",
-					gpuInfo.UUID,
-				)
-			}
-		} else {
-			slog.Debug("Could not query GPU virtualization mode",
-				slog.String("gpu_uuid", gpuInfo.UUID),
-				slog.String("error", nvml.ErrorString(ret)))
-		}
-
-		gpmSupport, ret := device.GpmQueryDeviceSupport()
-		if ret != nvml.SUCCESS {
-			return false, fmt.Sprintf("GPU %s GPM support query failed: %s", gpuInfo.UUID, nvml.ErrorString(ret))
-		}
-		if gpmSupport.IsSupportedDevice == 0 {
-			return false, fmt.Sprintf("GPU %s does not support GPM", gpuInfo.UUID)
-		}
-
-		if !probeGPMSample(device) {
-			return false, fmt.Sprintf("GPU %s failed GPM sample probe", gpuInfo.UUID)
+	// When profiling is retained but some GPUs cannot serve GPM metrics, surface the
+	// partial-coverage situation so operators of heterogeneous nodes understand why a
+	// subset of GPUs is missing DCGM_FI_PROF_* values.
+	if !disableDCP {
+		if broken := countStatus(statuses, gpmBroken); broken > 0 {
+			slog.Warn("Some GPUs failed the GPM probe; profiling metrics will be incomplete for those GPUs",
+				slog.Int("gpm_broken_gpus", broken),
+				slog.Int("total_gpus", int(gpuCount)))
 		}
 	}
 
-	return true, ""
+	return disableDCP, reason
 }
 
+// gpmStatusForGPU determines the GPM status of a single GPU using NVML.
+func gpmStatusForGPU(gpuID uint) gpuGPMStatus {
+	gpuInfo, err := dcgmprovider.Client().GetDeviceInfo(gpuID)
+	if err != nil {
+		slog.Debug("GPM validation: could not get device info",
+			slog.Uint64("gpu_id", uint64(gpuID)),
+			slog.String("error", err.Error()))
+		return gpmUnknown
+	}
+
+	device, ret := nvml.DeviceGetHandleByUUID(gpuInfo.UUID)
+	if ret != nvml.SUCCESS {
+		slog.Debug("GPM validation: could not get NVML handle",
+			slog.String("gpu_uuid", gpuInfo.UUID),
+			slog.String("error", nvml.ErrorString(ret)))
+		return gpmUnknown
+	}
+
+	gpmSupport, ret := device.GpmQueryDeviceSupport()
+	if ret != nvml.SUCCESS {
+		slog.Debug("GPM validation: GPM support query failed",
+			slog.String("gpu_uuid", gpuInfo.UUID),
+			slog.String("error", nvml.ErrorString(ret)))
+		return gpmUnknown
+	}
+	if gpmSupport.IsSupportedDevice == 0 {
+		// GPU does not use GPM for profiling; the DCGM profiling module serves its
+		// DCGM_FI_PROF_* fields, so GPM sample availability is irrelevant here.
+		return gpmNotApplicable
+	}
+
+	if !probeGPMSample(device) {
+		return gpmBroken
+	}
+	return gpmHealthy
+}
+
+// decideDCPFromGPMStatuses implements the per-GPU DCP policy. Profiling is disabled
+// globally only when at least one GPM-capable GPU is broken and no GPU (healthy GPM,
+// non-GPM/DCP-module, or not-yet-determined) can serve profiling metrics.
+func decideDCPFromGPMStatuses(statuses []gpuGPMStatus) (bool, string) {
+	healthy := countStatus(statuses, gpmHealthy)
+	broken := countStatus(statuses, gpmBroken)
+	notApplicable := countStatus(statuses, gpmNotApplicable)
+	unknown := countStatus(statuses, gpmUnknown)
+
+	if broken > 0 && healthy == 0 && notApplicable == 0 && unknown == 0 {
+		return true, fmt.Sprintf(
+			"all %d GPM-capable GPU(s) failed the live GPM probe; disabling profiling metrics "+
+				"(fractional vGPU guests cannot provide GPM samples, see issue #661)", broken)
+	}
+	return false, ""
+}
+
+func countStatus(statuses []gpuGPMStatus, want gpuGPMStatus) int {
+	n := 0
+	for _, s := range statuses {
+		if s == want {
+			n++
+		}
+	}
+	return n
+}
+
+// probeGPMSample takes two GPM samples and computes a metric from them to confirm that
+// GPM data can actually be retrieved at runtime. Fractional vGPU guests advertise GPM
+// support but fail here, which is the runtime signal used to gate profiling.
 func probeGPMSample(device nvml.Device) bool {
 	sample1, ret := nvml.GpmSampleAlloc()
 	if ret != nvml.SUCCESS {

--- a/internal/pkg/profiling/gpm_test.go
+++ b/internal/pkg/profiling/gpm_test.go
@@ -19,41 +19,92 @@ package profiling
 import (
 	"testing"
 
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
 )
 
-func TestVirtualizationModeBlocksGPM(t *testing.T) {
+func TestDecideDCPFromGPMStatuses(t *testing.T) {
 	tests := []struct {
-		name  string
-		mode  nvml.GpuVirtualizationMode
-		block bool
+		name        string
+		statuses    []gpuGPMStatus
+		wantDisable bool
 	}{
 		{
-			name:  "passthrough allows GPM",
-			mode:  nvml.GPU_VIRTUALIZATION_MODE_PASSTHROUGH,
-			block: false,
+			name:        "no GPUs keeps profiling",
+			statuses:    nil,
+			wantDisable: false,
 		},
 		{
-			name:  "none allows GPM",
-			mode:  nvml.GPU_VIRTUALIZATION_MODE_NONE,
-			block: false,
+			name:        "single non-GPM GPU (pre-Hopper A100) keeps profiling via DCP module",
+			statuses:    []gpuGPMStatus{gpmNotApplicable},
+			wantDisable: false,
 		},
 		{
-			name:  "vGPU guest blocks GPM",
-			mode:  nvml.GPU_VIRTUALIZATION_MODE_VGPU,
-			block: true,
+			name:        "single healthy GPM GPU (full GPU shape) keeps profiling",
+			statuses:    []gpuGPMStatus{gpmHealthy},
+			wantDisable: false,
 		},
 		{
-			name:  "host vGPU blocks GPM",
-			mode:  nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU,
-			block: true,
+			name:        "single broken GPM GPU (fractional vGPU) disables profiling",
+			statuses:    []gpuGPMStatus{gpmBroken},
+			wantDisable: true,
+		},
+		{
+			name:        "homogeneous fractional vGPU node disables profiling",
+			statuses:    []gpuGPMStatus{gpmBroken, gpmBroken, gpmBroken, gpmBroken},
+			wantDisable: true,
+		},
+		{
+			name:        "mixed healthy and broken GPM keeps profiling for healthy GPUs",
+			statuses:    []gpuGPMStatus{gpmHealthy, gpmBroken},
+			wantDisable: false,
+		},
+		{
+			name:        "non-GPM plus broken GPM keeps profiling for the DCP-module GPU",
+			statuses:    []gpuGPMStatus{gpmNotApplicable, gpmBroken},
+			wantDisable: false,
+		},
+		{
+			name:        "unknown plus broken stays conservative and keeps profiling",
+			statuses:    []gpuGPMStatus{gpmUnknown, gpmBroken},
+			wantDisable: false,
+		},
+		{
+			name:        "all unknown keeps profiling",
+			statuses:    []gpuGPMStatus{gpmUnknown},
+			wantDisable: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.block, VirtualizationModeBlocksGPM(tt.mode))
+			disable, reason := decideDCPFromGPMStatuses(tt.statuses)
+			assert.Equal(t, tt.wantDisable, disable)
+			if tt.wantDisable {
+				assert.NotEmpty(t, reason, "a disable decision must carry a reason")
+			} else {
+				assert.Empty(t, reason, "a keep decision must not carry a reason")
+			}
 		})
 	}
+}
+
+func TestCountStatus(t *testing.T) {
+	statuses := []gpuGPMStatus{gpmHealthy, gpmBroken, gpmBroken, gpmNotApplicable, gpmUnknown}
+
+	assert.Equal(t, 1, countStatus(statuses, gpmHealthy))
+	assert.Equal(t, 2, countStatus(statuses, gpmBroken))
+	assert.Equal(t, 1, countStatus(statuses, gpmNotApplicable))
+	assert.Equal(t, 1, countStatus(statuses, gpmUnknown))
+	assert.Equal(t, 0, countStatus(nil, gpmBroken))
+}
+
+// TestValidateGPMSupportRemoteHostengine verifies that remote hostengine deployments
+// skip local NVML validation entirely: local NVML cannot resolve GPUs owned by a
+// remote DCGM host, so DCGM's own capability result must be trusted.
+func TestValidateGPMSupportRemoteHostengine(t *testing.T) {
+	disable, reason := ValidateGPMSupport(&appconfig.Config{UseRemoteHE: true})
+	assert.False(t, disable)
+	assert.Empty(t, reason)
 }

--- a/internal/pkg/profiling/gpm_test.go
+++ b/internal/pkg/profiling/gpm_test.go
@@ -17,11 +17,16 @@
 package profiling
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
+	mockdcgm "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/dcgmprovider"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/dcgmprovider"
 )
 
 func TestDecideDCPFromGPMStatuses(t *testing.T) {
@@ -100,11 +105,167 @@ func TestCountStatus(t *testing.T) {
 	assert.Equal(t, 0, countStatus(nil, gpmBroken))
 }
 
+// fakeChecker is a test double for gpmDeviceChecker that returns pre-programmed
+// per-UUID statuses without touching NVML or a real GPU.
+type fakeChecker struct {
+	initOK         bool
+	statuses       map[string]gpuGPMStatus
+	shutdownCalled bool
+}
+
+func (f *fakeChecker) init() bool { return f.initOK }
+
+func (f *fakeChecker) shutdown() { f.shutdownCalled = true }
+
+func (f *fakeChecker) statusForUUID(uuid string) gpuGPMStatus {
+	if s, ok := f.statuses[uuid]; ok {
+		return s
+	}
+	return gpmUnknown
+}
+
+// withChecker swaps the package-level deviceChecker for the duration of a test.
+func withChecker(t *testing.T, c gpmDeviceChecker) {
+	t.Helper()
+	prev := deviceChecker
+	deviceChecker = c
+	t.Cleanup(func() { deviceChecker = prev })
+}
+
+// withMockDCGM installs a mock DCGM client for the duration of a test.
+func withMockDCGM(t *testing.T) *mockdcgm.MockDCGM {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	mock := mockdcgm.NewMockDCGM(ctrl)
+	prev := dcgmprovider.Client()
+	dcgmprovider.SetClient(mock)
+	t.Cleanup(func() { dcgmprovider.SetClient(prev) })
+	return mock
+}
+
 // TestValidateGPMSupportRemoteHostengine verifies that remote hostengine deployments
 // skip local NVML validation entirely: local NVML cannot resolve GPUs owned by a
 // remote DCGM host, so DCGM's own capability result must be trusted.
 func TestValidateGPMSupportRemoteHostengine(t *testing.T) {
+	// A checker whose init would fail proves the remote path returns before touching it.
+	withChecker(t, &fakeChecker{initOK: false})
+
 	disable, reason := ValidateGPMSupport(&appconfig.Config{UseRemoteHE: true})
 	assert.False(t, disable)
 	assert.Empty(t, reason)
+}
+
+func TestValidateGPMSupport(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(m *mockdcgm.MockDCGM)
+		checker     *fakeChecker
+		wantDisable bool
+	}{
+		{
+			name: "NVML unavailable keeps profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(2), nil)
+			},
+			checker:     &fakeChecker{initOK: false},
+			wantDisable: false,
+		},
+		{
+			name: "device count error keeps profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(0), errors.New("dcgm unavailable"))
+			},
+			checker:     &fakeChecker{initOK: true},
+			wantDisable: false,
+		},
+		{
+			name: "zero GPUs keeps profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(0), nil)
+			},
+			checker:     &fakeChecker{initOK: true},
+			wantDisable: false,
+		},
+		{
+			name: "single healthy GPM GPU keeps profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(1), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{UUID: "GPU-0"}, nil)
+			},
+			checker:     &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{"GPU-0": gpmHealthy}},
+			wantDisable: false,
+		},
+		{
+			name: "single pre-Hopper GPU keeps profiling via DCP module",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(1), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{UUID: "GPU-0"}, nil)
+			},
+			checker:     &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{"GPU-0": gpmNotApplicable}},
+			wantDisable: false,
+		},
+		{
+			name: "single broken GPM GPU disables profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(1), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{UUID: "GPU-0"}, nil)
+			},
+			checker:     &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{"GPU-0": gpmBroken}},
+			wantDisable: true,
+		},
+		{
+			name: "homogeneous fractional vGPU node disables profiling",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(2), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{UUID: "GPU-0"}, nil)
+				m.EXPECT().GetDeviceInfo(uint(1)).Return(dcgm.Device{UUID: "GPU-1"}, nil)
+			},
+			checker: &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{
+				"GPU-0": gpmBroken,
+				"GPU-1": gpmBroken,
+			}},
+			wantDisable: true,
+		},
+		{
+			name: "mixed healthy and broken GPM keeps profiling for healthy GPU",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(2), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{UUID: "GPU-0"}, nil)
+				m.EXPECT().GetDeviceInfo(uint(1)).Return(dcgm.Device{UUID: "GPU-1"}, nil)
+			},
+			checker: &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{
+				"GPU-0": gpmHealthy,
+				"GPU-1": gpmBroken,
+			}},
+			wantDisable: false,
+		},
+		{
+			name: "device info error yields unknown and stays conservative",
+			setup: func(m *mockdcgm.MockDCGM) {
+				m.EXPECT().GetAllDeviceCount().Return(uint(2), nil)
+				m.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{}, errors.New("device gone"))
+				m.EXPECT().GetDeviceInfo(uint(1)).Return(dcgm.Device{UUID: "GPU-1"}, nil)
+			},
+			checker: &fakeChecker{initOK: true, statuses: map[string]gpuGPMStatus{
+				"GPU-1": gpmBroken,
+			}},
+			wantDisable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := withMockDCGM(t)
+			tt.setup(mock)
+			withChecker(t, tt.checker)
+
+			disable, reason := ValidateGPMSupport(&appconfig.Config{})
+			assert.Equal(t, tt.wantDisable, disable)
+			if tt.wantDisable {
+				assert.NotEmpty(t, reason)
+			} else {
+				assert.Empty(t, reason)
+			}
+		})
+	}
 }

--- a/internal/pkg/profiling/gpm_test.go
+++ b/internal/pkg/profiling/gpm_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package profiling
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVirtualizationModeBlocksGPM(t *testing.T) {
+	tests := []struct {
+		name  string
+		mode  nvml.GpuVirtualizationMode
+		block bool
+	}{
+		{
+			name:  "passthrough allows GPM",
+			mode:  nvml.GPU_VIRTUALIZATION_MODE_PASSTHROUGH,
+			block: false,
+		},
+		{
+			name:  "none allows GPM",
+			mode:  nvml.GPU_VIRTUALIZATION_MODE_NONE,
+			block: false,
+		},
+		{
+			name:  "vGPU guest blocks GPM",
+			mode:  nvml.GPU_VIRTUALIZATION_MODE_VGPU,
+			block: true,
+		},
+		{
+			name:  "host vGPU blocks GPM",
+			mode:  nvml.GPU_VIRTUALIZATION_MODE_HOST_VGPU,
+			block: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.block, VirtualizationModeBlocksGPM(tt.mode))
+		})
+	}
+}

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -980,10 +980,10 @@ func queryDCPMetrics(config *appconfig.Config, reloadID uint64) {
 		return
 	}
 
-	if supported, reason := profiling.ValidateGPMSupport(); !supported {
+	if disableDCP, reason := profiling.ValidateGPMSupport(config); disableDCP {
 		config.CollectDCP = false
 		config.MetricGroups = nil
-		slog.Info("Not collecting DCP metrics: GPM validation failed",
+		slog.Info("Not collecting DCP metrics: GPM validation disabled profiling",
 			slog.Uint64("reload_id", reloadID),
 			slog.String("reason", reason))
 		return

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/logging"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/prerequisites"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/profiling"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/registry"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/server"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/stdout"
@@ -976,6 +977,15 @@ func queryDCPMetrics(config *appconfig.Config, reloadID uint64) {
 		config.CollectDCP = false
 		config.MetricGroups = nil
 		slog.Info("Not collecting DCP metrics: " + err.Error())
+		return
+	}
+
+	if supported, reason := profiling.ValidateGPMSupport(); !supported {
+		config.CollectDCP = false
+		config.MetricGroups = nil
+		slog.Info("Not collecting DCP metrics: GPM validation failed",
+			slog.Uint64("reload_id", reloadID),
+			slog.String("reason", reason))
 		return
 	}
 

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -955,6 +955,9 @@ func getCounters(ctx context.Context, config *appconfig.Config) *counters.Counte
 	return cs
 }
 
+// validateGPMSupportFn is a seam for tests to stub GPM validation without NVML.
+var validateGPMSupportFn = profiling.ValidateGPMSupport
+
 // queryDCPMetrics queries DCGM for supported profiling metric groups.
 // Called at: startup, GPU bind event (NOT regular hot reload - uses startup config).
 // If profiling not supported or query fails, DCP collection is disabled.
@@ -980,7 +983,7 @@ func queryDCPMetrics(config *appconfig.Config, reloadID uint64) {
 		return
 	}
 
-	if disableDCP, reason := profiling.ValidateGPMSupport(config); disableDCP {
+	if disableDCP, reason := validateGPMSupportFn(config); disableDCP {
 		config.CollectDCP = false
 		config.MetricGroups = nil
 		slog.Info("Not collecting DCP metrics: GPM validation disabled profiling",

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"errors"
 	"flag"
 	"strconv"
 	"testing"
@@ -366,4 +367,73 @@ func Test_contextToConfig_DumpConfig(t *testing.T) {
 			assert.Equal(t, tt.expectedConfig, config.DumpConfig)
 		})
 	}
+}
+
+// TestQueryDCPMetrics verifies how queryDCPMetrics translates the metric-group query
+// and GPM validation result into config.CollectDCP / config.MetricGroups. GPM
+// validation is stubbed via validateGPMSupportFn so the test runs without NVML.
+func TestQueryDCPMetrics(t *testing.T) {
+	origClient := dcgmprovider.Client()
+	defer dcgmprovider.SetClient(origClient)
+	origFn := validateGPMSupportFn
+	defer func() { validateGPMSupportFn = origFn }()
+
+	groups := []dcgm.MetricGroup{{Major: 1, Minor: 0, FieldIds: []uint{1001, 1004}}}
+
+	t.Run("metric group query error disables DCP without validating", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mock := mockdcgmprovider.NewMockDCGM(ctrl)
+		dcgmprovider.SetClient(mock)
+		mock.EXPECT().GetSupportedMetricGroups(uint(0)).Return(nil, errors.New("not supported"))
+
+		validateGPMSupportFn = func(*appconfig.Config) (bool, string) {
+			t.Fatal("validation must not run when the metric group query fails")
+			return false, ""
+		}
+
+		config := &appconfig.Config{CollectDCP: true}
+		queryDCPMetrics(config, 0)
+
+		assert.False(t, config.CollectDCP)
+		assert.Nil(t, config.MetricGroups)
+	})
+
+	t.Run("GPM validation disable turns off DCP", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mock := mockdcgmprovider.NewMockDCGM(ctrl)
+		dcgmprovider.SetClient(mock)
+		mock.EXPECT().GetSupportedMetricGroups(uint(0)).Return(groups, nil)
+
+		validateGPMSupportFn = func(*appconfig.Config) (bool, string) {
+			return true, "all GPM-capable GPUs failed the probe"
+		}
+
+		config := &appconfig.Config{CollectDCP: true}
+		queryDCPMetrics(config, 0)
+
+		assert.False(t, config.CollectDCP)
+		assert.Nil(t, config.MetricGroups)
+	})
+
+	t.Run("GPM validation keep enables DCP with metric groups", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mock := mockdcgmprovider.NewMockDCGM(ctrl)
+		dcgmprovider.SetClient(mock)
+		mock.EXPECT().GetSupportedMetricGroups(uint(0)).Return(groups, nil)
+		mock.EXPECT().GetAllDeviceCount().Return(uint(1), nil).AnyTimes()
+		mock.EXPECT().GetDeviceInfo(uint(0)).Return(dcgm.Device{}, nil).AnyTimes()
+
+		validateGPMSupportFn = func(*appconfig.Config) (bool, string) {
+			return false, ""
+		}
+
+		config := &appconfig.Config{}
+		queryDCPMetrics(config, 0)
+
+		assert.True(t, config.CollectDCP)
+		assert.Equal(t, groups, config.MetricGroups)
+	})
 }


### PR DESCRIPTION
## Problem

On GKE G4 nodes with fractional GPU allocations (g4-standard-6, g4-standard-12, g4-standard-24), dcgm-exporter emits repeated errors:

```
Got unexpected return -14 from m_gpmManager.GetLatestSample
```

and exports no profiling metrics. Full GPU shapes (g4-standard-48+) are unaffected.

The root cause is that fractional vGPU guests run under `GPU_VIRTUALIZATION_MODE_VGPU`, which prevents GPM (GPU Performance Monitoring) from collecting samples. The exporter attempted to collect DCP/profiling metrics unconditionally, resulting in a continuous error loop.

Fixes #661

## Solution

Introduce `internal/pkg/profiling` with `ValidateGPMSupport()`, which runs before DCP metric collection on each reload cycle and:

1. Queries each GPU's virtualization mode via NVML `GetVirtualizationMode` — immediately returns unsupported for vGPU guest modes.
2. Queries `GpmQueryDeviceSupport` to check hardware-level GPM capability.
3. Performs a live two-sample GPM probe to confirm metrics can actually be retrieved at runtime.

When any GPU fails validation, DCP/profiling collection is disabled for that cycle while all standard DCGM metrics continue to be exported normally.

## Test plan

- [x] Unit tests for `VirtualizationModeBlocksGPM` covering all virtualization mode variants
- [ ] Verify on a full GPU shape (g4-standard-48+): DCP metrics continue to be collected
- [ ] Verify on a fractional vGPU shape (g4-standard-6/12/24): no GPM errors, standard metrics still exported