### PR TITLE
fix(build): copy all libs from the dcgm deb, plus all libnvperf prefixed libs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -309,7 +309,10 @@ RUN set -e; \
     ARCH_DIR=$(ls -d /usr/lib/*-linux-gnu | head -n1 | xargs basename); \
     mkdir -p /opt/distroless-libs/$ARCH_DIR; \
     cp -P /usr/lib/$ARCH_DIR/libdcgm* /opt/distroless-libs/$ARCH_DIR/ || true; \
-    cp -P /usr/lib/$ARCH_DIR/libnvperf_dcgm* /opt/distroless-libs/$ARCH_DIR/ || true; \
+    cp -P /usr/lib/$ARCH_DIR/libnvperf* /opt/distroless-libs/$ARCH_DIR/ || true; \
+    for so in $(dpkg -L datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary 2>/dev/null | grep -E '^/usr/lib/.*\.so(\.|$)'); do \
+        cp -P "$so" /opt/distroless-libs/$ARCH_DIR/ 2>/dev/null || true; \
+    done; \
     cp -P /usr/lib/$ARCH_DIR/libcap.so* /opt/distroless-libs/$ARCH_DIR/ || true; \
     cp -P /usr/lib/$ARCH_DIR/libtinfo.so* /opt/distroless-libs/$ARCH_DIR/ || true; \
     ls -la /opt/distroless-libs/$ARCH_DIR/


### PR DESCRIPTION
potentially closes #700 

NVIDIA wants to ship distroless images only. it appears the distroless library copy from the ubuntu-based distroless-helper build stage is missing libs required to emit all profiling and some clock metrics

after building and running this in my environment i can confirm that the metrics shown missing in #700 now appear.