### PR TITLE
grafana: include hostname in GPU legends

### DIFF
--- a/grafana/dcgm-exporter-dashboard.json
+++ b/grafana/dcgm-exporter-dashboard.json
@@ -93,7 +93,7 @@
           "expr": "DCGM_FI_DEV_GPU_TEMP{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "instant": false,
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -245,7 +245,7 @@
         {
           "expr": "DCGM_FI_DEV_POWER_USAGE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -405,7 +405,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -496,7 +496,7 @@
         {
           "expr": "DCGM_FI_DEV_GPU_UTIL{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -586,7 +586,7 @@
         {
           "expr": "DCGM_FI_DEV_FB_USED{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],
@@ -676,7 +676,7 @@
         {
           "expr": "DCGM_FI_PROF_PIPE_TENSOR_ACTIVE{instance=~\"$instance\", gpu=~\"$gpu\"}",
           "interval": "",
-          "legendFormat": "GPU {{gpu}}",
+          "legendFormat": "{{hostname}} - GPU {{gpu}}",
           "refId": "A"
         }
       ],


### PR DESCRIPTION
## Summary
- include the exporter `hostname` label in GPU panel legends
- update GPU time-series legends from `GPU {{gpu}}` to `{{hostname}} - GPU {{gpu}}`

## Why
In multi-node clusters, every node can have `gpu="0"`, `gpu="1"`, etc. Showing only the GPU index makes dashboard series ambiguous. Including `hostname` lets operators distinguish the node and GPU directly in the legend.

Fixes NVIDIA/dcgm-exporter#630.

## Validation
- `python3 -m json.tool grafana/dcgm-exporter-dashboard.json >/dev/null`
- `git diff --check`
