### PR TITLE
fix: release NVML handles on GPU topology change in Kubernetes mode

### DIFF
--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -896,6 +896,8 @@ type reloadCoordinator struct {
 	applyTopologyChange func(ctx context.Context, reloadID uint64)
 	buildRegistry       func(ctx context.Context, c *cli.Context, cfg *appconfig.Config) (*registry.Registry, devicewatchlistmanager.Manager, error)
 	initializeDCGM      func(cfg *appconfig.Config)
+	cleanupNVML         func()
+	initializeNVML      func() error
 	gpuWatcher          gpuWatcherLifecycle
 }
 
@@ -912,6 +914,8 @@ func newReloadCoordinator(c *cli.Context, dcgmCleanup func()) *reloadCoordinator
 	r.applyTopologyChange = r.doTopologyChange
 	r.buildRegistry = buildRegistryFunc
 	r.initializeDCGM = initializeDCGMProviderFunc
+	r.cleanupNVML = func() { nvmlprovider.Client().Cleanup() }
+	r.initializeNVML = initializeNVMLProviderFunc
 	return r
 }
 
@@ -1095,9 +1099,26 @@ func (r *reloadCoordinator) doTopologyChange(ctx context.Context, reloadID uint6
 		oldRegistry.Cleanup()
 	}
 
+	// Release ALL GPU handles before reinitializing any of them. A GPU driver
+	// unbind — the common trigger for a topology change under DRA/VFIO — only
+	// completes once the GPU's kernel usage count reaches zero. Both DCGM (via
+	// the embedded hostengine) and, in Kubernetes mode, NVML hold open
+	// /dev/nvidia* handles. If DCGM reinitializes and reopens those handles
+	// before NVML has been released, the usage count never reaches zero, so the
+	// kernel logs "Attempting to remove device ... with non-zero usage count!"
+	// and the unbind hangs until the pod restarts. Draining both providers
+	// before either reinitializes gives the kernel the zero-usage window it
+	// needs to finish the unbind, after which reinitialization re-attaches to
+	// whatever GPUs remain. NVML cleanup/reinit is gated on cfg.Kubernetes to
+	// mirror the startup init condition exactly.
 	slog.InfoContext(ctx, "Cleaning up DCGM resources",
 		slog.Uint64("reload_id", reloadID))
 	r.dcgmCleanup()
+
+	if cfg.Kubernetes {
+		slog.InfoContext(ctx, "Cleaning up NVML resources", slog.Uint64("reload_id", reloadID))
+		r.cleanupNVML()
+	}
 
 	slog.InfoContext(ctx, "Reinitializing DCGM",
 		slog.Uint64("reload_id", reloadID))
@@ -1106,12 +1127,9 @@ func (r *reloadCoordinator) doTopologyChange(ctx context.Context, reloadID uint6
 		r.gpuWatcher.Start()
 	}
 
-	if cfg.Kubernetes && cfg.KubernetesVirtualGPUs {
-		slog.InfoContext(ctx, "Cleaning up NVML resources", slog.Uint64("reload_id", reloadID))
-		nvmlprovider.Client().Cleanup()
-
+	if cfg.Kubernetes {
 		slog.InfoContext(ctx, "Reinitializing NVML", slog.Uint64("reload_id", reloadID))
-		if err := nvmlprovider.Initialize(); err != nil {
+		if err := r.initializeNVML(); err != nil {
 			slog.ErrorContext(ctx, "Failed to reinitialize NVML",
 				slog.Uint64("reload_id", reloadID),
 				slog.String("error", err.Error()))

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -2772,6 +2772,100 @@ func TestDoTopologyChangeSuccessInstallsRegistry(t *testing.T) {
 	assert.False(t, coord.dcp.collectDCP)
 }
 
+// TestDoTopologyChange_ReleasesNVMLInKubernetesMode is the regression for
+// https://github.com/NVIDIA/dcgm-exporter/issues/706. NVML is initialized at
+// startup for every Kubernetes deployment, and it holds open file handles on
+// /dev/nvidia*. A GPU driver unbind that triggers a topology change stays
+// blocked ("non-zero usage count") until those handles are released. The reset
+// must therefore clean up and reinitialize NVML whenever Kubernetes mode is on,
+// even when virtual GPUs are NOT enabled — which was the buggy pre-condition.
+func TestDoTopologyChange_ReleasesNVMLInKubernetesMode(t *testing.T) {
+	mock := withMockDCGMClient(t)
+	mock.EXPECT().GetSupportedMetricGroups(uint(0)).Return(nil, errors.New("profiling unsupported"))
+
+	coord := newTestCoordinator(t)
+	coord.reloadConfig.Kubernetes = true
+	coord.reloadConfig.KubernetesVirtualGPUs = false // the config from issue #706
+
+	// Record the exact order of provider drain/reinit calls. The kernel only
+	// completes a GPU driver unbind once BOTH DCGM and NVML have released their
+	// /dev/nvidia* handles; if either reinitializes (reopening the handles)
+	// before the other has been drained, the usage count never reaches zero and
+	// the unbind hangs. This is the regression for issue #706: the sequence must
+	// be drain-all-then-reinit-all, not drain/reinit each provider in turn.
+	var mu sync.Mutex
+	var order []string
+	record := func(s string) { mu.Lock(); order = append(order, s); mu.Unlock() }
+	coord.dcgmCleanup = func() { record("dcgm-cleanup") }
+	coord.initializeDCGM = func(*appconfig.Config) { record("dcgm-init") }
+	coord.cleanupNVML = func() { record("nvml-cleanup") }
+	coord.initializeNVML = func() error { record("nvml-init"); return nil }
+
+	coord.buildRegistry = func(
+		context.Context,
+		*cli.Context,
+		*appconfig.Config,
+	) (*registry.Registry, devicewatchlistmanager.Manager, error) {
+		return registry.NewRegistry(), topologyManager(), nil
+	}
+
+	coord.handle(context.Background(), evTopologyChanged)
+
+	require.Contains(t, order, "nvml-cleanup",
+		"NVML must be cleaned up during a topology change in Kubernetes mode to release /dev/nvidia* handles")
+	require.Contains(t, order, "nvml-init",
+		"NVML must be reinitialized after a topology change in Kubernetes mode")
+
+	idx := func(s string) int {
+		for i, v := range order {
+			if v == s {
+				return i
+			}
+		}
+		return -1
+	}
+	// Both providers must be drained before either is reinitialized, so the GPU
+	// usage count can reach zero and the pending unbind can complete.
+	assert.Less(t, idx("dcgm-cleanup"), idx("dcgm-init"), "DCGM must drain before it reinitializes")
+	assert.Less(t, idx("nvml-cleanup"), idx("nvml-init"), "NVML must drain before it reinitializes")
+	assert.Less(t, idx("nvml-cleanup"), idx("dcgm-init"),
+		"NVML must be drained BEFORE DCGM reinitializes, else DCGM reopens /dev/nvidia* and the unbind stays blocked")
+	assert.Less(t, idx("dcgm-cleanup"), idx("nvml-init"),
+		"DCGM must be drained BEFORE NVML reinitializes, so both handles are released simultaneously")
+}
+
+// TestDoTopologyChange_SkipsNVMLWhenNotKubernetes proves the NVML reset is
+// scoped to Kubernetes mode, mirroring the startup init condition: when NVML
+// was never initialized there is nothing to release.
+func TestDoTopologyChange_SkipsNVMLWhenNotKubernetes(t *testing.T) {
+	mock := withMockDCGMClient(t)
+	mock.EXPECT().GetSupportedMetricGroups(uint(0)).Return(nil, errors.New("profiling unsupported"))
+
+	coord := newTestCoordinator(t)
+	coord.reloadConfig.Kubernetes = false
+	coord.dcgmCleanup = func() {}
+	coord.initializeDCGM = func(*appconfig.Config) {}
+
+	var nvmlCleanups, nvmlInits atomic.Int32
+	coord.cleanupNVML = func() { nvmlCleanups.Add(1) }
+	coord.initializeNVML = func() error { nvmlInits.Add(1); return nil }
+
+	coord.buildRegistry = func(
+		context.Context,
+		*cli.Context,
+		*appconfig.Config,
+	) (*registry.Registry, devicewatchlistmanager.Manager, error) {
+		return registry.NewRegistry(), topologyManager(), nil
+	}
+
+	coord.handle(context.Background(), evTopologyChanged)
+
+	assert.Equal(t, int32(0), nvmlCleanups.Load(),
+		"NVML must not be touched during a topology change outside Kubernetes mode")
+	assert.Equal(t, int32(0), nvmlInits.Load(),
+		"NVML must not be reinitialized during a topology change outside Kubernetes mode")
+}
+
 // TestReloadCoordinator_RepublishedDCPReplacesPreviousSnapshot proves the
 // load-bearing refresh invariant for the topology-change path: once a later
 // query publishes a new DCP snapshot, the next config reload must use that


### PR DESCRIPTION
NVML is initialized for every Kubernetes deployment (config.Kubernetes) and opens handles on /dev/nvidia*, but the topology-change reset only released it when KubernetesVirtualGPUs was also set. With the common config (DCGM_EXPORTER_KUBERNETES=true, virtual GPUs unset), the handles were never released, leaving a GPU driver unbind blocked with "non-zero usage count" until the pod restarted.

Gate NVML cleanup/reinit on cfg.Kubernetes to mirror the startup init condition, and add coordinator seams so it is unit-testable.

Fixes #706