### PR TITLE
feat(counters): add power limit metrics to default and dcp counter files

### DIFF
--- a/etc/dcp-metrics-included.csv
+++ b/etc/dcp-metrics-included.csv
@@ -12,6 +12,8 @@ DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
 
 # Power
 DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+DCGM_FI_DEV_POWER_MGMT_LIMIT,         gauge, Configured power management limit (in W).
+DCGM_FI_DEV_ENFORCED_POWER_LIMIT,     gauge, Effective power limit enforced by the driver after all limiters (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
 # PCIE

--- a/etc/default-counters.csv
+++ b/etc/default-counters.csv
@@ -12,6 +12,8 @@ DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
 
 # Power
 DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
+DCGM_FI_DEV_POWER_MGMT_LIMIT,         gauge, Configured power management limit (in W).
+DCGM_FI_DEV_ENFORCED_POWER_LIMIT,     gauge, Effective power limit enforced by the driver after all limiters (in W).
 DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
 
 # PCIE


### PR DESCRIPTION
what : - 
Add DCGM_FI_DEV_POWER_MGMT_LIMIT and DCGM_FI_DEV_ENFORCED_POWER_LIMIT
to default-counters.csv and dcp-metrics-included.csv.
why:-
When GPU inference performance degrades unexpectedly, a common cause is the GPU hitting its power limit. As power draw approaches the enforced limit, the driver can reduce SM clock frequencies to remain within the available power budget, directly affecting inference throughput and latency.
Currently, dcgm-exporter exposes metrics such as DCGM_FI_DEV_POWER_USAGE and DCGM_FI_DEV_SM_CLOCK, allowing operators to observe the symptoms of power throttling. However, the configured and enforced power limits are not included in the default exporter metrics.
Operators cannot directly correlate reduced clock frequencies or increased inference latency with the GPU's power limit from Prometheus alone. They need to query DCGM or nvidia-smi separately to determine whether power capping is the underlying cause. This is particularly problematic in remote or managed environments where operators do not have direct access to the underlying system

Related Issue: 720