### PR TITLE
feat: add daemonSetAnnotations to the Helm chart

### DIFF
--- a/deployment/templates/daemonset.yaml
+++ b/deployment/templates/daemonset.yaml
@@ -19,6 +19,10 @@ metadata:
   namespace: {{ include "dcgm-exporter.namespace" . }}
   labels:
     {{- include "dcgm-exporter.labels" . | nindent 4 }}
+  {{- with .Values.daemonSetAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   updateStrategy:
     type: RollingUpdate

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -116,6 +116,10 @@ podLabels: {}
 
 # Annotations to be added to dcgm-exporter pods
 podAnnotations: {}
+
+# daemonSetAnnotations are applied to the DaemonSet object itself.
+# Use podAnnotations above to annotate the pods.
+daemonSetAnnotations: {}
 # Using this annotation which is required for prometheus scraping
   # prometheus.io/scrape: "true"
   # prometheus.io/port: "9400"


### PR DESCRIPTION
## What

The chart exposes `podAnnotations`, which renders at `spec.template.metadata` and
annotates the **pods**. The DaemonSet **object's** own metadata takes only
`name`, `namespace` and `labels`, so there is no way to annotate the DaemonSet
itself.

Object annotations are how IaC tooling and GitOps controllers attach behaviour to
a resource — reconciliation hints, sync options, wait/skip directives. In our
case a Pulumi deployment needs `pulumi.com/skipAwait` on the DaemonSet and
currently has to post-process the rendered manifest to get it.

## How

Adds a `daemonSetAnnotations` value, guarded with `{{- with }}` and defaulting to
`{}`. `podAnnotations` is untouched and keeps annotating the pods.

I did not bump `version` in `Chart.yaml` — the history shows chart and app
versions are moved together at release time (`DCGM-Exporter 4.6.0-4.8.3`), so it
looked wrong to bump it in a feature PR. Happy to add a bump if you would prefer.

## Rendered behaviour

| values | result |
|---|---|
| `daemonSetAnnotations` unset (default) | **byte-identical** to the unmodified chart — 422 lines |
| `daemonSetAnnotations` set | exactly 2 lines, the DaemonSet's `metadata.annotations` |

```
$ diff before.yaml after.yaml     # key unset
$ diff after.yaml set.yaml
253a254,255
>   annotations:
>     pulumi.com/skipAwait: "true"
```

`helm lint` passes. Commit is signed off per CONTRIBUTING.
