### PR TITLE
Generate the linker cache in the distroless image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -316,6 +316,10 @@ COPY --from=runtime-distroless-helper --chown=root:root --chmod=755 /opt/distrol
 COPY --from=runtime-distroless-helper --chown=root:root --chmod=644 /etc/passwd /etc/
 COPY --from=runtime-distroless-helper --chown=root:root --chmod=644 /etc/group /etc/
 
+# dcgmLibExistsRule resolves libdcgm.so.4 through `ldconfig -p`, which needs this
+# cache (#612). Tolerated as above: ldconfig can segfault under QEMU cross-builds.
+RUN /sbin/ldconfig || true
+
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility,compat32
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all


### PR DESCRIPTION
Fixes #612.

`dcgmLibExistsRule` resolves `libdcgm.so.4` by parsing `ldconfig -p`, and the distroless image ships `/etc/ld.so.conf.d` but no `/etc/ld.so.cache`. `ldconfig -p` exits 1, the error is returned unwrapped, and the process dies printing only its banner and a bare `exit status 1`:

```
execve("/sbin/ldconfig", ["-p"])      = 0
openat("/etc/ld.so.cache", O_RDONLY)  = -1 ENOENT
exit_group(1)
```

Reproduces with no GPU and no Kubernetes:

```console
$ docker run --rm nvcr.io/nvidia/k8s/dcgm-exporter:4.8.3
time=… level=INFO msg="Starting dcgm-exporter" Version=4.6.0-4.8.3
exit status 1
```

The library is present the whole time — `dlopen()` finds it on the default search path. Only the probe needs the cache.

Distroless-only because `runtime-ubuntu` (line 187) and `runtime-distroless-helper` (line 260) both run `ldconfig`, but the helper's cache never reaches the final image, and `runtime-distroless` copies the libraries in without regenerating it. Same reason the workarounds in #612 work: the `*-ubuntu22.04` tags ship a cache, and `runtimeClassName: nvidia` gets one from the container-toolkit hook.

**Change:** one `RUN` in the distroless stage, failure tolerated as in the stages above (`ldconfig` can segfault under QEMU cross-builds).

**Validation:** I can't build the full multi-stage image locally, so I applied the same command to the published image, which has the identical final-stage filesystem — `ldconfig -p` then resolves `libdcgm.so.4 => /lib/x86_64-linux-gnu/libdcgm.so.4` and the exporter starts. Also verified on GKE (12 × L4, driver 580.126.20, GKE-managed drivers, no GPU Operator): with an init container generating the same cache, 12/12 DaemonSet pods run with 0 restarts and export `DCGM_FI_PROF_*` with pod attribution. `make test-images` needs a build environment I don't have, so CI is the real check.

Happy to drop the `|| true`, or move generation into the helper stage, if either fits your build setup better.