### PR TITLE
fix(collector): label each NVSwitch entity with its own ID

### DIFF
--- a/internal/pkg/collector/gpu_collector.go
+++ b/internal/pkg/collector/gpu_collector.go
@@ -638,12 +638,17 @@ func toSwitchMetric(
 		if useOld {
 			uuid = "uuid"
 		}
+		// A switch entity is its own identity; only NvLink entities carry the switch as parent.
+		nvLink, nvSwitch := "", fmt.Sprintf("nvswitch%d", mi.Entity.EntityId)
+		if mi.Entity.EntityGroupId == dcgm.FE_LINK {
+			nvLink, nvSwitch = fmt.Sprintf("%d", mi.Entity.EntityId), fmt.Sprintf("nvswitch%d", mi.ParentId)
+		}
 		m := Metric{
 			Counter:    counter,
 			Value:      v,
 			UUID:       uuid,
-			NvLink:     fmt.Sprintf("%d", mi.Entity.EntityId),
-			NvSwitch:   fmt.Sprintf("nvswitch%d", mi.ParentId),
+			NvLink:     nvLink,
+			NvSwitch:   nvSwitch,
 			Hostname:   hostname,
 			Labels:     labels,
 			Attributes: nil,

--- a/internal/pkg/collector/gpu_collector_test.go
+++ b/internal/pkg/collector/gpu_collector_test.go
@@ -1360,7 +1360,8 @@ func TestDCGMCollectorGetMetricsEntityBranches(t *testing.T) {
 			},
 			assertion: func(t *testing.T, got Metric) {
 				assert.Equal(t, "11", got.Value)
-				assert.Equal(t, "3", got.NvLink)
+				assert.Equal(t, "nvswitch3", got.NvSwitch)
+				assert.Empty(t, got.NvLink)
 			},
 		},
 		{
@@ -1508,6 +1509,27 @@ func TestToSwitchMetric(t *testing.T) {
 	assert.Equal(t, "nvswitch9", got.NvSwitch)
 	assert.Equal(t, "host-a", got.Hostname)
 	assert.Equal(t, map[string]string{"switch_label": "fabric-a"}, got.Labels)
+}
+
+func TestToSwitchMetric_SwitchEntityUsesOwnID(t *testing.T) {
+	valueCounter := counters.Counter{FieldID: 4, FieldName: "DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT", PromType: "gauge"}
+	metrics := MetricsByCounter{}
+
+	for _, id := range []uint{0, 1, 2, 3} {
+		mi := devicemonitoring.Info{
+			Entity:     dcgm.GroupEntityPair{EntityGroupId: dcgm.FE_SWITCH, EntityId: id},
+			ParentId:   devicemonitoring.PARENT_ID_IGNORED,
+			ParentType: dcgm.FE_NONE,
+		}
+		toSwitchMetric(metrics, []dcgm.FieldValue_v1{int64FieldValue(valueCounter.FieldID, 40)},
+			[]counters.Counter{valueCounter}, mi, false, "host-a")
+	}
+
+	require.Len(t, metrics[valueCounter], 4)
+	for i, got := range metrics[valueCounter] {
+		assert.Equal(t, fmt.Sprintf("nvswitch%d", i), got.NvSwitch)
+		assert.Empty(t, got.NvLink)
+	}
 }
 
 func TestToCPUMetric(t *testing.T) {


### PR DESCRIPTION
Fixes #728

On a node with several NVSwitches, every `DCGM_FE_SWITCH` metric was labelled `nvswitch="nvswitch0"`.

`monitorAllSwitches` builds switch entities with `PARENT_ID_IGNORED`, but `toSwitchMetric` derived the `nvswitch` label from `mi.ParentId`. That is right for NvLink children of a switch and wrong for the switch itself, where the identity is the entity ID.

The fix uses `Entity.EntityId` for switch entities and keeps `ParentId` for NvLink entities. Switch metrics no longer carry an `nvlink` value.

One existing test in `TestDCGMCollectorGetMetricsEntityBranches` asserted `nvlink="3"` for a switch entity, which was the bug. It now checks `nvswitch="nvswitch3"`. A new test renders four switches and checks the four labels are distinct.

Verified with `go test ./internal/pkg/collector/ ./internal/pkg/rendermetrics/` on Linux. I do not have a multi-switch node at hand, so a confirmation from @shield-9 on real hardware would be welcome.
