### PR TITLE
fix: deduplicate HPC job IDs before metric enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ These mapping files follow a specific format:
 
 * Each file is named after either a unique GPU ID or a unique GPU ID and a GPU instance (MIG) ID separated with a "." (e.g., 0, 1, 2.0, 2.1, 3, etc.).
 * Each line in the file contains JOB IDs that run on the corresponding GPU/MIG instance.
+* Repeated job IDs within a file are included only once. The same job ID can still be mapped to multiple GPUs/MIG instances.
 
 #### Enabling HPC Job Mapping on DCGM-Exporter
 

--- a/internal/pkg/server/server_test.go
+++ b/internal/pkg/server/server_test.go
@@ -22,6 +22,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -569,4 +571,51 @@ func TestDumpMetricsToJSON(t *testing.T) {
 		assert.Contains(t, string(data), "TEST_METRIC")
 		assert.Contains(t, string(data), "testhost")
 	})
+}
+
+func TestMetricsWithRepeatedHPCJobIDs(t *testing.T) {
+	mappingDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(mappingDir, "0"), []byte("job1\njob2\njob1\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(mappingDir, "1"), []byte("job1\n"), 0o600))
+	ctrl := gomock.NewController(t)
+	mockCollector := mockcollectorpkg.NewMockCollector(ctrl)
+	mockCollector.EXPECT().GetMetrics().DoAndReturn(func() (collector.MetricsByCounter, error) {
+		metrics := getMetricsByCounterWithTestMetric()
+		secondGPU := metrics[getTestMetric()][0]
+		secondGPU.GPU = "1"
+		secondGPU.GPUDevice = "nvidia1"
+		secondGPU.GPUUUID = "GPU-00000000-0000-0000-0000-000000000001"
+		metrics[getTestMetric()] = append(metrics[getTestMetric()], secondGPU)
+		return metrics, nil
+	}).Times(2)
+	reg := registry.NewRegistry()
+	tuple := collector.EntityCollectorTuple{}
+	tuple.SetEntity(dcgm.FE_GPU)
+	tuple.SetCollector(mockCollector)
+	reg.Register(tuple)
+	mockDeviceInfo := mockdeviceinfo.NewMockProvider(ctrl)
+	mockDeviceInfo.EXPECT().InfoType().Return(dcgm.FE_GPU).AnyTimes()
+	mockDeviceInfo.EXPECT().GOpts().Return(appconfig.DeviceOptions{}).AnyTimes()
+	mockDeviceInfo.EXPECT().GPUCount().Return(uint(2)).AnyTimes()
+	watchList := *devicewatchlistmanager.NewWatchList(mockDeviceInfo, []dcgm.Short{42}, nil, deviceWatcher, 1)
+	watchManager := mockdevicewatchlistmanager.NewMockManager(ctrl)
+	watchManager.EXPECT().EntityWatchList(dcgm.FE_GPU).Return(watchList, true).Times(2)
+	metricServer := &MetricsServer{
+		deviceWatchListManager: watchManager,
+		transformations:        transformation.GetTransformations(&appconfig.Config{HPCJobMappingDir: mappingDir}),
+	}
+	metricServer.registry.Store(reg)
+	recorder := httptest.NewRecorder()
+	metricServer.Metrics(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Equal(t, 2, strings.Count(recorder.Body.String(), `hpc_job="job1"`))
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), `hpc_job="job2"`))
+
+	require.NoError(t, os.WriteFile(filepath.Join(mappingDir, "0"), []byte("job3\njob3\n"), 0o600))
+	recorder = httptest.NewRecorder()
+	metricServer.Metrics(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), `hpc_job="job1"`))
+	require.NotContains(t, recorder.Body.String(), `hpc_job="job2"`)
+	require.Equal(t, 1, strings.Count(recorder.Body.String(), `hpc_job="job3"`))
 }

--- a/internal/pkg/transformation/hpc.go
+++ b/internal/pkg/transformation/hpc.go
@@ -149,8 +149,14 @@ func readFile(path string) ([]string, error) {
 	// job2
 	// job3
 	scanner := bufio.NewScanner(file)
+	seen := make(map[string]struct{})
 	for scanner.Scan() {
-		jobs = append(jobs, scanner.Text())
+		job := scanner.Text()
+		if _, exists := seen[job]; exists {
+			continue
+		}
+		seen[job] = struct{}{}
+		jobs = append(jobs, job)
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/internal/pkg/transformation/hpc_test.go
+++ b/internal/pkg/transformation/hpc_test.go
@@ -317,3 +317,15 @@ func TestGetGPUFiles(t *testing.T) {
 func TestHPCName(t *testing.T) {
 	assert.Equal(t, "hpcMapper", newHPCMapper(&appconfig.Config{}).Name())
 }
+
+func TestReadHPCMappingDeduplicatesJobsInOrder(t *testing.T) {
+	realOS := osinterface.RealOS{}
+	file, err := realOS.CreateTemp(t.TempDir(), "mapping")
+	require.NoError(t, err)
+	_, err = file.WriteString("job2\njob1\njob2\njob3\njob1\n")
+	require.NoError(t, err)
+	require.NoError(t, file.Close())
+	jobs, err := readFile(file.Name())
+	require.NoError(t, err)
+	require.Equal(t, []string{"job2", "job1", "job3"}, jobs)
+}


### PR DESCRIPTION
Repeated job IDs in a GPU mapping file produce duplicate metric samples. The renderer rejects their identical labels, causing `/metrics` to return HTTP 500.

Deduplicate IDs within each file while preserving their first-seen order. The same job can still appear on multiple GPUs or MIG instances.

Add a regression using real mapping files and the metrics HTTP handler. It covers duplicate IDs, a job shared by two GPUs, and updated file contents on the next scrape. Document the duplicate-ID behavior.

Validation:
- The HTTP handler regression fails with status 500 on upstream and returns 200 with this change.
- Server and transformation package tests with `-race -short -count=1` passed.
- CPU short tests passed across 47 tested packages, excluding `internal/pkg/integration_test`.
- `make lint LINT_BASE_REV=HEAD`: 0 issues.
- `make check-fmt`: passed.

`make test-main` could not pass the DCGM integration package because `libdcgm.so.4` is unavailable in this environment. GPU/DCGM integration was not validated.
