### PR TITLE
Tolerate nvidia.com/gpu taint in Helm chart and raw manifest defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ helm install \
     gpu-helm-charts/dcgm-exporter
 ```
 
+The chart's default `tolerations` allow the DaemonSet to schedule on nodes tainted with `nvidia.com/gpu` (the taint used by the NVIDIA device plugin and GPU Operator) and on control-plane nodes. If your GPU nodes carry a different taint, override `tolerations` in your values, otherwise the DaemonSet will not schedule any pods on them.
+
 Once the `dcgm-exporter` pod is deployed, you can use port forwarding to obtain metrics quickly:
 
 ```shell

--- a/dcgm-exporter.yaml
+++ b/dcgm-exporter.yaml
@@ -70,6 +70,10 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+      tolerations:
+      - key: nvidia.com/gpu
+        operator: Exists
+        effect: NoSchedule
       volumes:
       - name: "pod-gpu-resources"
         hostPath:

--- a/deployment/values.yaml
+++ b/deployment/values.yaml
@@ -191,6 +191,9 @@ tolerations:
   - key: node-role.kubernetes.io/control-plane
     operator: Exists
     effect: NoSchedule
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
 #- operator: Exists
 
 affinity: {}

--- a/tests/static/chart_rbac_rendering_test.go
+++ b/tests/static/chart_rbac_rendering_test.go
@@ -580,6 +580,7 @@ type chartResource struct {
 				AutomountServiceAccountToken *bool             `yaml:"automountServiceAccountToken"`
 				Containers                   []container       `yaml:"containers"`
 				ImagePullSecrets             []imagePullSecret `yaml:"imagePullSecrets"`
+				Tolerations                  []toleration      `yaml:"tolerations"`
 				Volumes                      []volume          `yaml:"volumes"`
 			} `yaml:"spec"`
 		} `yaml:"template"`
@@ -605,6 +606,13 @@ type container struct {
 
 type imagePullSecret struct {
 	Name string `yaml:"name"`
+}
+
+// toleration captures the pod toleration fields needed by the scheduling contract.
+type toleration struct {
+	Key      string `yaml:"key"`
+	Operator string `yaml:"operator"`
+	Effect   string `yaml:"effect"`
 }
 
 type serviceMonitorEndpoint struct {

--- a/tests/static/chart_scheduling_rendering_test.go
+++ b/tests/static/chart_scheduling_rendering_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package static_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	gpuTaintKey          = "nvidia.com/gpu"
+	controlPlaneTaintKey = "node-role.kubernetes.io/control-plane"
+)
+
+// TestChartDefaultTolerationsRenderContract verifies the default DaemonSet can schedule on tainted GPU nodes.
+func TestChartDefaultTolerationsRenderContract(t *testing.T) {
+	resources := renderChart(t, nil)
+
+	daemonSet := requireResourceKind(t, resources, "DaemonSet")
+	tolerations := daemonSet.Spec.Template.Spec.Tolerations
+	assertToleratesNoSchedule(t, tolerations, controlPlaneTaintKey)
+	assertToleratesNoSchedule(t, tolerations, gpuTaintKey)
+}
+
+// TestChartTolerationsOverrideReplacesDefaults verifies user-supplied tolerations are rendered verbatim.
+func TestChartTolerationsOverrideReplacesDefaults(t *testing.T) {
+	resources := renderChart(t, map[string]interface{}{
+		"tolerations": []interface{}{
+			map[string]interface{}{
+				"key":      "example.com/accelerator",
+				"operator": "Exists",
+				"effect":   "NoSchedule",
+			},
+		},
+	})
+
+	daemonSet := requireResourceKind(t, resources, "DaemonSet")
+	tolerations := daemonSet.Spec.Template.Spec.Tolerations
+	require.Len(t, tolerations, 1)
+	assert.Equal(t, "example.com/accelerator", tolerations[0].Key)
+	assert.Equal(t, "Exists", tolerations[0].Operator)
+	assert.Equal(t, "NoSchedule", tolerations[0].Effect)
+}
+
+// TestStandaloneManifestToleratesGPUTaint keeps the raw DaemonSet manifest aligned with the chart default.
+func TestStandaloneManifestToleratesGPUTaint(t *testing.T) {
+	manifest, err := os.ReadFile(repoPath(t, "dcgm-exporter.yaml"))
+	require.NoError(t, err)
+
+	resources := parseManifest(t, string(manifest))
+	daemonSet := requireResourceKind(t, resources, "DaemonSet")
+	assertToleratesNoSchedule(t, daemonSet.Spec.Template.Spec.Tolerations, gpuTaintKey)
+}
+
+// assertToleratesNoSchedule requires an Exists/NoSchedule toleration for the given taint key.
+func assertToleratesNoSchedule(t *testing.T, tolerations []toleration, key string) {
+	t.Helper()
+
+	for _, tol := range tolerations {
+		if tol.Key == key && tol.Operator == "Exists" && tol.Effect == "NoSchedule" {
+			return
+		}
+	}
+	t.Errorf("no Exists/NoSchedule toleration for taint %q in %+v", key, tolerations)
+}


### PR DESCRIPTION
## Problem

Installing the chart with default values on a cluster whose GPU nodes are tainted `nvidia.com/gpu=true:NoSchedule` (the pattern used by EKS/GKE GPU node groups, Karpenter/Cluster Autoscaler GPU pools, and what the NVIDIA device plugin and GPU Operator expect) produces a DaemonSet with `DESIRED 0 / CURRENT 0`. The release reports success, but no exporter pods run and no metrics are exposed. The `dcgm-exporter.yaml` standalone manifest has the same behaviour, and the README says nothing about taints.

## Root cause

`deployment/values.yaml:190-193` only ships a `node-role.kubernetes.io/control-plane` toleration:

```yaml
tolerations:
  - key: node-role.kubernetes.io/control-plane
    operator: Exists
    effect: NoSchedule
```

`deployment/templates/daemonset.yaml:74-77` renders that list verbatim (`{{- with .Values.tolerations }}` / `toYaml`), so nodes carrying the `nvidia.com/gpu` taint are ineligible for the DaemonSet. `dcgm-exporter.yaml` (DaemonSet spec, before `volumes:`) has no `tolerations` at all. The NVIDIA device plugin chart tolerates `nvidia.com/gpu` `Exists`/`NoSchedule` by default, so installing both side by side yields the device plugin on the GPU nodes and dcgm-exporter nowhere.

## Fix

- `deployment/values.yaml`: add an `nvidia.com/gpu` / `operator: Exists` / `effect: NoSchedule` toleration to the default list, matching the device plugin chart. Users who set `tolerations` themselves are unaffected because the template renders only what is in values.
- `dcgm-exporter.yaml`: add the same toleration to the standalone DaemonSet so the raw manifest stays aligned with the chart defaults.
- `README.md`: one sentence after the `helm install` step explaining which taints the defaults tolerate and that `tolerations` must be overridden for other taints.
- `tests/static/chart_scheduling_rendering_test.go` (new) plus a `tolerations` field on the existing render-contract structs in `tests/static/chart_rbac_rendering_test.go`: static chart tests asserting the default DaemonSet tolerates `nvidia.com/gpu`, that a user-supplied `tolerations` list replaces the defaults, and that `dcgm-exporter.yaml` carries the same toleration.

No chart version bump; versions are bumped in release commits in this repository.

## How tested

New static tests (`go test ./tests/static -run 'Toleration|Tolerates'`), run against the unchanged `values.yaml` / `dcgm-exporter.yaml` first:

```
--- FAIL: TestChartDefaultTolerationsRenderContract (0.01s)
    chart_scheduling_rendering_test.go:39: no Exists/NoSchedule toleration for taint "nvidia.com/gpu" in [{Key:node-role.kubernetes.io/control-plane Operator:Exists Effect:NoSchedule}]
--- FAIL: TestStandaloneManifestToleratesGPUTaint (0.00s)
    chart_scheduling_rendering_test.go:69: no Exists/NoSchedule toleration for taint "nvidia.com/gpu" in []
FAIL
FAIL	github.com/NVIDIA/dcgm-exporter/tests/static	0.056s
```

With the fix applied:

```
--- PASS: TestChartDefaultTolerationsRenderContract (0.01s)
--- PASS: TestChartTolerationsOverrideReplacesDefaults (0.01s)
--- PASS: TestStandaloneManifestToleratesGPUTaint (0.00s)
ok  	github.com/NVIDIA/dcgm-exporter/tests/static	0.040s
```

The full static suite (`make test-static` / `go test ./tests/static`) passes, and `gofmt -l tests/static` and `go vet ./tests/static` are clean.

Rendered the DaemonSet with default values before and after (`helm template test deployment/ --show-only templates/daemonset.yaml`).

Before (only the control-plane taint is tolerated; `grep -c nvidia.com/gpu` returns 0, exit 1):

```yaml
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
        operator: Exists
      volumes:
```

After (`grep -c nvidia.com/gpu` returns 1, exit 0):

```yaml
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/control-plane
        operator: Exists
      - effect: NoSchedule
        key: nvidia.com/gpu
        operator: Exists
      volumes:
```

Also verified:

- `helm lint deployment/` passes (1 chart linted, 0 failed).
- Overriding the list still replaces the defaults entirely: `helm template test deployment/ --set 'tolerations[0].key=foo' --set 'tolerations[0].operator=Exists'` renders only the `foo` toleration.
- `dcgm-exporter.yaml` still parses as two documents (DaemonSet, Service) and the DaemonSet pod spec carries the new toleration.

Kubernetes e2e tests were not run (no GPU cluster available here).

## Links

- Issue: https://github.com/NVIDIA/dcgm-exporter/issues/731
- Device plugin default toleration: https://github.com/NVIDIA/k8s-device-plugin/blob/main/deployments/helm/nvidia-device-plugin/values.yaml

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
