### PR TITLE
Add optional cgroup-direct attribution for shared GPU memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,28 @@ DCGM_FI_DEV_MEMORY_TEMP{gpu="0", UUID="GPU-604ac76c-d9cf-fef3-62e9-d92044ab6e52"
 To integrate DCGM-Exporter with Prometheus and Grafana, see the full instructions in the [user guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/).
 `dcgm-exporter` is deployed as part of the GPU Operator. To get started with integrating with Prometheus, check the Operator [user guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#gpu-telemetry).
 
+### Direct cgroup attribution for shared GPU memory
+
+When shared-GPU logical assignments do not match actual GPU usage, enable:
+
+```shell
+dcgm-exporter --kubernetes --kubernetes-virtual-gpus --kubernetes-enable-pod-uid \
+  --kubernetes-process-mapping-mode=cgroup-direct
+```
+
+The default is `pod-resources`. Alternatively, set
+`DCGM_EXPORTER_KUBERNETES_PROCESS_MAPPING_MODE=cgroup-direct`.
+
+Direct mode aggregates non-MIG `DCGM_FI_DEV_FB_USED` in MiB by physical GPU UUID
+and cgroup Pod UID. Device totals, MIG, and other metrics retain their behavior.
+Pod samples omit `container` and `vgpu`; select `{pod_uid!=""}` to exclude device
+totals. Cached Pod metadata enriches labels; missing metadata leaves UID-only
+attribution. Unresolved processes are skipped; idle-Pod zeros are not inferred.
+
+Requires all three Kubernetes flags above, host process cgroup access (typically
+`hostPID: true`), and Pod list/watch permissions for metadata. NVML must expose
+workload Pod PIDs; an MPS server PID alone cannot identify client Pods.
+
 ### TLS and Basic Auth
 
 Exporter supports TLS and basic auth using [exporter-toolkit](https://github.com/prometheus/exporter-toolkit). To use TLS and/or basic auth, users need to use `--web-config-file` CLI flag as follows

--- a/internal/pkg/appconfig/const.go
+++ b/internal/pkg/appconfig/const.go
@@ -20,6 +20,9 @@ const (
 	GPUUID     KubernetesGPUIDType = "uid"
 	DeviceName KubernetesGPUIDType = "device-name"
 
+	ProcessMappingPodResources KubernetesProcessMappingMode = "pod-resources"
+	ProcessMappingCgroupDirect KubernetesProcessMappingMode = "cgroup-direct"
+
 	NvidiaResourceName      = "nvidia.com/gpu"
 	NvidiaMigResourcePrefix = "nvidia.com/mig-"
 	MIG_UUID_PREFIX         = "MIG-"

--- a/internal/pkg/appconfig/types.go
+++ b/internal/pkg/appconfig/types.go
@@ -42,6 +42,8 @@ const (
 
 type KubernetesGPUIDType string
 
+type KubernetesProcessMappingMode string
+
 type DeviceOptions struct {
 	Flex       bool  // If true, then monitor all GPUs if MIG mode is disabled or all GPU instances if MIG is enabled.
 	MajorRange []int // The indices of each GPU/NvSwitch to monitor, or -1 to monitor all
@@ -124,6 +126,7 @@ type Config struct {
 	ContainerRuntimeSocket           string
 	NvidiaResourceNames              []string
 	KubernetesVirtualGPUs            bool
+	KubernetesProcessMappingMode     KubernetesProcessMappingMode
 	DumpConfig                       DumpConfig // Configuration for file-based dumps
 	KubernetesEnableDRA              bool
 	DisableStartupValidate           bool

--- a/internal/pkg/transformation/kubernetes.go
+++ b/internal/pkg/transformation/kubernetes.go
@@ -40,6 +40,7 @@ import (
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -267,15 +268,32 @@ func (p *PodMapper) createPerProcessMetrics(
 	}
 
 	devicePods := dataMap.deviceToPods[metricsKey]
-	if len(devicePods) == 0 {
-		return nil, nil
+	memory, direct := dataMap.podMemory[val.GPUUUID]
+	direct = direct && counter.FieldName == metricFBUsed && val.GPUInstanceID == "" && val.MigProfile == ""
+	var podValues map[string]string
+	if direct {
+		devicePods = make([]PodInfo, 0, len(memory))
+		podValues = make(map[string]string, len(memory))
+		for _, uid := range slices.Sorted(maps.Keys(memory)) {
+			podInfo := dataMap.podInfoByUID[uid]
+			podInfo.UID = uid
+			devicePods = append(devicePods, podInfo)
+			podValues[uid] = fmt.Sprintf("%d", memory[uid]/(1024*1024))
+		}
+	} else {
+		if len(devicePods) == 0 {
+			return nil, nil
+		}
+		data := dataMap.metrics[metricsKey]
+		podValues = buildPodValueMap(dataMap.pidToPod, data, counter.FieldName)
+		maps.Copy(podValues, buildIdlePodValues(podValues, devicePods))
 	}
 
-	data := dataMap.metrics[metricsKey]
-	podValues := buildPodValueMap(dataMap.pidToPod, data, counter.FieldName)
-	maps.Copy(podValues, buildIdlePodValues(podValues, devicePods))
-
 	var result []collector.Metric
+	if direct {
+		// A handled metric with no Pod processes must not fall back to logical slots.
+		result = make([]collector.Metric, 0, len(devicePods))
+	}
 	for _, podInfo := range devicePods {
 		value, ok := podValues[podInfo.UID]
 		if !ok {
@@ -288,14 +306,21 @@ func (p *PodMapper) createPerProcessMetrics(
 		}
 		metric.Value = value
 
-		if !p.Config.UseOldNamespace {
-			metric.Attributes[podAttribute] = podInfo.Name
-			metric.Attributes[namespaceAttribute] = podInfo.Namespace
-			metric.Attributes[containerAttribute] = podInfo.Container
-		} else {
-			metric.Attributes[oldPodAttribute] = podInfo.Name
-			metric.Attributes[oldNamespaceAttribute] = podInfo.Namespace
-			metric.Attributes[oldContainerAttribute] = podInfo.Container
+		if metric.Attributes == nil {
+			metric.Attributes = make(map[string]string)
+		}
+		podKey, namespaceKey, containerKey := podAttribute, namespaceAttribute, containerAttribute
+		if p.Config.UseOldNamespace {
+			podKey, namespaceKey, containerKey = oldPodAttribute, oldNamespaceAttribute, oldContainerAttribute
+		}
+		if !direct || podInfo.Name != "" {
+			metric.Attributes[podKey] = podInfo.Name
+		}
+		if !direct || podInfo.Namespace != "" {
+			metric.Attributes[namespaceKey] = podInfo.Namespace
+		}
+		if !direct {
+			metric.Attributes[containerKey] = podInfo.Container
 		}
 		metric.Attributes[uidAttribute] = podInfo.UID
 		if podInfo.VGPU != "" {
@@ -303,6 +328,12 @@ func (p *PodMapper) createPerProcessMetrics(
 		}
 		if len(podInfo.Labels) > 0 {
 			copyPodLabels(&metric, podInfo.Labels, getMetricGroup())
+		}
+		if direct {
+			for _, key := range []string{containerAttribute, oldContainerAttribute, vgpuAttribute} {
+				delete(metric.Attributes, key)
+				delete(metric.Labels, key)
+			}
 		}
 		for k := range metric.Attributes {
 			delete(metric.Labels, k)
@@ -394,6 +425,8 @@ func (p *PodMapper) getMappings(deviceInfo deviceinfo.Provider) (map[string][]Po
 }
 
 func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo deviceinfo.Provider) error {
+	cgroupDirect := p.Config.Kubernetes && p.Config.KubernetesVirtualGPUs && p.Config.KubernetesEnablePodUID &&
+		p.Config.KubernetesProcessMappingMode == appconfig.ProcessMappingCgroupDirect
 	deviceToPods, deviceToPod, deviceToPodsDRA, err := p.getMappings(deviceInfo)
 	if err != nil {
 		if status.Code(err) == codes.ResourceExhausted {
@@ -405,7 +438,9 @@ func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo devic
 		} else {
 			slog.Warn("Failed to get pod mappings", "error", err)
 		}
-		return nil // Don't fail the whole scrape, just skip enrichment
+		if !cgroupDirect {
+			return nil // Don't fail the whole scrape, just skip enrichment
+		}
 	}
 
 	metricGroup := dcgm.FE_NONE
@@ -419,24 +454,37 @@ func (p *PodMapper) Process(metrics collector.MetricsByCounter, deviceInfo devic
 	}
 
 	if p.Config.KubernetesVirtualGPUs {
-		if deviceToPods == nil {
+		if deviceToPods == nil && !cgroupDirect {
 			return nil
 		}
 		slog.Debug(fmt.Sprintf("Device to sharing pods mapping: %+v", deviceToPods))
 
 		gpuUUIDToDeviceID := getGPUUUIDToDeviceID(deviceInfo, p.Config.KubernetesGPUIdType)
 		processCollector := &perProcessCollector{
-			client:    nvmlprovider.Client(),
-			pidMapper: newPIDToPodMapper(),
+			client:       nvmlprovider.Client(),
+			pidMapper:    newPIDToPodMapper(),
+			cgroupDirect: cgroupDirect,
 		}
 		perProcessData := processCollector.Collect(gpuUUIDToDeviceID, deviceToPods, deviceInfo)
+		if cgroupDirect {
+			perProcessData.podInfoByUID = p.getPodInfoByUID()
+		}
 
 		for counter := range metrics {
 			var newmetrics []collector.Metric
 			for j, val := range metrics[counter] {
-				deviceID, err := val.GetIDOfType(p.Config.KubernetesGPUIdType)
-				if err != nil {
-					return err
+				_, direct := perProcessData.podMemory[val.GPUUUID]
+				direct = direct && counter.FieldName == metricFBUsed && val.GPUInstanceID == "" && val.MigProfile == ""
+				if deviceToPods == nil && !direct {
+					newmetrics = append(newmetrics, val)
+					continue
+				}
+				var deviceID string
+				if !direct {
+					deviceID, err = val.GetIDOfType(p.Config.KubernetesGPUIdType)
+					if err != nil {
+						return err
+					}
 				}
 
 				podInfos := deviceToPods[deviceID]
@@ -1156,6 +1204,26 @@ func (p *PodMapper) toDeviceToPod(
 		"totalMappings", len(deviceToPodMap),
 		"deviceToPodMap", fmt.Sprintf("%+v", deviceToPodMap))
 	return deviceToPodMap
+}
+
+// getPodInfoByUID reads cached metadata independently of device assignments.
+func (p *PodMapper) getPodInfoByUID() map[string]PodInfo {
+	result := make(map[string]PodInfo)
+	if p.podLister == nil {
+		return result
+	}
+	pods, err := p.podLister.List(labels.Everything())
+	if err != nil {
+		slog.Warn("Failed to read pod metadata for cgroup memory", "error", err)
+		return result
+	}
+	for _, pod := range pods {
+		info := p.createPodInfo(&podresourcesapi.PodResources{Name: pod.Name, Namespace: pod.Namespace}, nil)
+		if info.UID != "" {
+			result[info.UID] = info
+		}
+	}
+	return result
 }
 
 // createPodInfo creates a PodInfo struct with metadata if enabled

--- a/internal/pkg/transformation/kubernetes_test.go
+++ b/internal/pkg/transformation/kubernetes_test.go
@@ -243,6 +243,82 @@ func TestPodMapperProcessMissingPodResourcesSocketIsNoop(t *testing.T) {
 	assert.Empty(t, metrics[counter][0].Attributes)
 }
 
+func TestCgroupMemoryPreservesDeviceMetricsWithoutPodResources(t *testing.T) {
+	for _, socket := range []string{"missing", "not a socket"} {
+		t.Run(socket, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "kubelet.sock")
+			if socket == "not a socket" {
+				require.NoError(t, stdos.WriteFile(path, []byte("not a socket"), 0o600))
+			}
+			ctrl := gomock.NewController(t)
+			client := mocknvmlprovider.NewMockNVML(ctrl)
+			client.EXPECT().GetDeviceProcessMemory("GPU-1").Return(nil, errors.New("NVML unavailable"))
+			client.EXPECT().GetDeviceProcessUtilization("GPU-1").Return(nil, nil)
+			previous := nvmlprovider.Client()
+			nvmlprovider.SetClient(client)
+			t.Cleanup(func() { nvmlprovider.SetClient(previous) })
+			devInfo := mockdeviceinfo.NewMockProvider(ctrl)
+			devInfo.EXPECT().GPUCount().Return(uint(1)).AnyTimes()
+			devInfo.EXPECT().GPU(uint(0)).Return(deviceinfo.GPUInfo{DeviceInfo: dcgm.Device{UUID: "GPU-1"}}).AnyTimes()
+			mapper := &PodMapper{Config: &appconfig.Config{
+				Kubernetes: true, KubernetesVirtualGPUs: true, KubernetesEnablePodUID: true,
+				KubernetesProcessMappingMode: appconfig.ProcessMappingCgroupDirect,
+				KubernetesGPUIdType:          appconfig.GPUUID, PodResourcesKubeletSocket: path,
+			}}
+			metrics := make(collector.MetricsByCounter)
+			for _, name := range []string{metricFBUsed, metricGPUUtil, "DCGM_FI_DEV_POWER_USAGE"} {
+				counter := counters.Counter{FieldName: name}
+				metrics[counter] = []collector.Metric{{Counter: counter, GPUUUID: "GPU-1", Value: "100"}}
+			}
+			require.NoError(t, mapper.Process(metrics, devInfo))
+			for _, samples := range metrics {
+				require.Len(t, samples, 1)
+				assert.Equal(t, "100", samples[0].Value)
+				assert.Empty(t, samples[0].Attributes)
+			}
+		})
+	}
+}
+
+func TestCgroupMemoryPodMetadataAndLabels(t *testing.T) {
+	for _, oldNames := range []bool{false, true} {
+		t.Run(fmt.Sprintf("legacy labels=%t", oldNames), func(t *testing.T) {
+			mapper := &PodMapper{
+				Config:           &appconfig.Config{KubernetesEnablePodUID: true, KubernetesEnablePodLabels: true, UseOldNamespace: oldNames},
+				labelFilterCache: newLabelFilterCache([]string{"^app$"}, 10),
+			}
+			setupMockInformer(t, mapper, fake.NewSimpleClientset(&v1.Pod{ObjectMeta: metav1.ObjectMeta{
+				UID: "pod-1", Name: "workload-1", Namespace: "default",
+				Labels: map[string]string{"app": "training", "ignored": "value"},
+			}}))
+			data := &perProcessDataMap{
+				podMemory:    map[string]map[string]uint64{"GPU-1": {"pod-1": 3 * 1024 * 1024, "pod-2": 4 * 1024 * 1024}},
+				podInfoByUID: mapper.getPodInfoByUID(),
+			}
+			counter := counters.Counter{FieldName: metricFBUsed}
+			original := collector.Metric{
+				Counter: counter, GPUUUID: "GPU-1", Value: "100",
+				Attributes: map[string]string{vgpuAttribute: "5", containerAttribute: "app", oldContainerAttribute: "app"},
+			}
+			metrics, err := mapper.createPerProcessMetrics(original, counter, original, data,
+				func() dcgm.Field_Entity_Group { return dcgm.FE_GPU })
+			require.NoError(t, err)
+			require.Len(t, metrics, 2)
+			podKey, namespaceKey := podAttribute, namespaceAttribute
+			if oldNames {
+				podKey, namespaceKey = oldPodAttribute, oldNamespaceAttribute
+			}
+			assert.Equal(t, map[string]string{uidAttribute: "pod-1", podKey: "workload-1", namespaceKey: "default"}, metrics[0].Attributes)
+			assert.Equal(t, map[string]string{"app": "training"}, metrics[0].Labels)
+			assert.Equal(t, "3", metrics[0].Value)
+			assert.Equal(t, map[string]string{uidAttribute: "pod-2"}, metrics[1].Attributes)
+			assert.Equal(t, "4", metrics[1].Value)
+			assert.Equal(t, "5", original.Attributes[vgpuAttribute])
+			assert.Equal(t, "100", original.Value)
+		})
+	}
+}
+
 func TestPodMapperGetMappingsValidatesPodResourcesSocketPath(t *testing.T) {
 	regularFilePath := filepath.Join(t.TempDir(), "regular-file")
 	require.NoError(t, stdos.WriteFile(regularFilePath, []byte("not a socket"), 0o600))

--- a/internal/pkg/transformation/process_metrics.go
+++ b/internal/pkg/transformation/process_metrics.go
@@ -63,6 +63,9 @@ func (c *perProcessCollector) processRegularGPU(gpuUUID string, podInfos []PodIn
 	data.pidToMemory, err = c.client.GetDeviceProcessMemory(gpuUUID)
 	if err != nil {
 		slog.Debug("Failed to get process memory", "gpuUUID", gpuUUID, "error", err)
+		if c.cgroupDirect {
+			data.pidToMemory = nil
+		}
 	}
 
 	data.pidToSMUtil, err = c.client.GetDeviceProcessUtilization(gpuUUID)
@@ -102,16 +105,35 @@ func (m *perProcessMetrics) getValueForMetric(fieldName string, pid uint32) (uin
 type perProcessDataMap struct {
 	metrics      map[string]*perProcessMetrics // keyed by GPU UUID or "<parentUUID>/<gpuInstanceID>" for MIG
 	pidToPod     map[uint32]*PodInfo
-	deviceToPods map[string][]PodInfo // keyed by GPU UUID or "<parentUUID>/<gpuInstanceID>" for MIG
+	deviceToPods map[string][]PodInfo         // keyed by GPU UUID or "<parentUUID>/<gpuInstanceID>" for MIG
+	podMemory    map[string]map[string]uint64 // bytes keyed by physical GPU UUID and cgroup Pod UID
+	podInfoByUID map[string]PodInfo
 }
 
 type PIDMapper interface {
+	getPodUIDForPID(pid uint32) (string, error)
 	buildPIDToPodMap(pids []uint32, pods []PodInfo) map[uint32]*PodInfo
 }
 
 type perProcessCollector struct {
-	client    nvmlprovider.NVML
-	pidMapper PIDMapper
+	client       nvmlprovider.NVML
+	pidMapper    PIDMapper
+	cgroupDirect bool
+}
+
+func (c *perProcessCollector) aggregatePodMemory(memoryByPID map[uint32]uint64) map[string]uint64 {
+	result := make(map[string]uint64)
+	for pid, memory := range memoryByPID {
+		uid, err := c.pidMapper.getPodUIDForPID(pid)
+		if err != nil {
+			slog.Debug("Failed to map PID to pod for cgroup memory", "pid", pid, "error", err)
+			continue
+		}
+		if uid != "" {
+			result[uid] += memory
+		}
+	}
+	return result
 }
 
 func getMIGMetricsKey(parentUUID string, gpuInstanceID string) string {
@@ -159,15 +181,24 @@ func (c *perProcessCollector) Collect(gpuDeviceMap map[string]string, deviceToPo
 		metrics:      make(map[string]*perProcessMetrics),
 		pidToPod:     make(map[uint32]*PodInfo),
 		deviceToPods: make(map[string][]PodInfo),
+		podMemory:    make(map[string]map[string]uint64),
 	}
 
-	if devInfo == nil || c.client == nil {
+	if devInfo == nil || (c.client == nil && !c.cgroupDirect) {
 		return result
 	}
 
 	for i := uint(0); i < devInfo.GPUCount(); i++ {
 		gpu := devInfo.GPU(i)
 		gpuUUID := gpu.DeviceInfo.UUID
+		directMemory := c.cgroupDirect && !gpu.MigEnabled && len(gpu.GPUInstances) == 0
+		if directMemory {
+			// An empty entry keeps direct-mode failures from falling back to slot attribution.
+			result.podMemory[gpuUUID] = make(map[string]uint64)
+		}
+		if c.client == nil {
+			continue
+		}
 
 		if len(gpu.GPUInstances) > 0 {
 			metrics, pidToPod, keyToPods := c.processMIGEnabledGPU(gpu, deviceToPods)
@@ -177,10 +208,13 @@ func (c *perProcessCollector) Collect(gpuDeviceMap map[string]string, deviceToPo
 		} else {
 			deviceID := gpuDeviceMap[gpuUUID]
 			podInfos := deviceToPods[deviceID]
-			if len(podInfos) == 0 {
+			if len(podInfos) == 0 && !directMemory {
 				continue
 			}
 			data, pidToPod := c.processRegularGPU(gpuUUID, podInfos)
+			if directMemory {
+				result.podMemory[gpuUUID] = c.aggregatePodMemory(data.pidToMemory)
+			}
 			result.metrics[gpuUUID] = data
 			result.deviceToPods[gpuUUID] = podInfos
 			maps.Copy(result.pidToPod, pidToPod)

--- a/internal/pkg/transformation/process_metrics_test.go
+++ b/internal/pkg/transformation/process_metrics_test.go
@@ -17,26 +17,211 @@
 package transformation
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	mockdeviceinfo "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/deviceinfo"
 	mocknvmlprovider "github.com/NVIDIA/dcgm-exporter/internal/mocks/pkg/nvmlprovider"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/appconfig"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/collector"
+	"github.com/NVIDIA/dcgm-exporter/internal/pkg/counters"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/deviceinfo"
 	"github.com/NVIDIA/dcgm-exporter/internal/pkg/nvmlprovider"
 )
 
 type mockPIDMapper struct {
-	result map[uint32]*PodInfo
+	result   map[uint32]*PodInfo
+	errByPID map[uint32]error
+}
+
+func (m *mockPIDMapper) getPodUIDForPID(pid uint32) (string, error) {
+	if err := m.errByPID[pid]; err != nil {
+		return "", err
+	}
+	if pod := m.result[pid]; pod != nil {
+		return pod.UID, nil
+	}
+	return "", nil
 }
 
 func (m *mockPIDMapper) buildPIDToPodMap(pids []uint32, pods []PodInfo) map[uint32]*PodInfo {
 	return m.result
+}
+
+// TestPodResourcesMemoryAttributionLimitations covers issue #725 in both modes.
+func TestPodResourcesMemoryAttributionLimitations(t *testing.T) {
+	const (
+		gpuA   = "GPU-00000000-0000-0000-0000-000000000000"
+		gpuB   = "GPU-11111111-1111-1111-1111-111111111111"
+		podUID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+	)
+	pod := PodInfo{Name: "workload-1", Namespace: "default", UID: podUID, VGPU: "5"}
+	secondSlot := pod
+	secondSlot.VGPU = "19"
+
+	for _, tc := range []struct {
+		name         string
+		deviceToPods map[string][]PodInfo
+		direct       bool
+		wantSamples  int
+		wantQueries  int
+	}{
+		{
+			name:         "two logical slots must produce one Pod memory sample",
+			deviceToPods: map[string][]PodInfo{gpuB: {pod, secondSlot}},
+			direct:       true, wantSamples: 1, wantQueries: 1,
+		},
+		{
+			name:         "allocation on GPU A must not hide a process on GPU B",
+			deviceToPods: map[string][]PodInfo{gpuA: {pod}},
+			direct:       true, wantSamples: 1, wantQueries: 1,
+		},
+		{
+			name:         "default mode preserves logical slot samples",
+			deviceToPods: map[string][]PodInfo{gpuB: {pod, secondSlot}},
+			wantSamples:  2, wantQueries: 1,
+		},
+		{
+			name:         "default mode preserves candidate filtering",
+			deviceToPods: map[string][]PodInfo{gpuA: {pod}},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := mocknvmlprovider.NewMockNVML(ctrl)
+			client.EXPECT().GetDeviceProcessMemory(gpuB).Return(map[uint32]uint64{
+				101: 6 * 1024 * 1024,
+				102: 4 * 1024 * 1024,
+			}, nil).Times(tc.wantQueries)
+			client.EXPECT().GetDeviceProcessUtilization(gpuB).Return(map[uint32]uint32{101: 10, 102: 20}, nil).Times(tc.wantQueries)
+			devInfo := mockdeviceinfo.NewMockProvider(ctrl)
+			devInfo.EXPECT().GPUCount().Return(uint(1)).AnyTimes()
+			devInfo.EXPECT().GPU(uint(0)).Return(deviceinfo.GPUInfo{
+				DeviceInfo: dcgm.Device{UUID: gpuB},
+			}).AnyTimes()
+
+			// Seed the cgroup cache so no host /proc files are required.
+			pidMapper := newPIDToPodMapper()
+			pidMapper.pidToUID[101] = podUID
+			pidMapper.pidToUID[102] = podUID
+			processCollector := &perProcessCollector{client: client, pidMapper: pidMapper, cgroupDirect: tc.direct}
+			data := processCollector.Collect(map[string]string{gpuB: gpuB}, tc.deviceToPods, devInfo)
+
+			mapper := &PodMapper{Config: &appconfig.Config{
+				Kubernetes: true, KubernetesVirtualGPUs: true, KubernetesEnablePodUID: true,
+			}}
+			counter := counters.Counter{FieldName: metricFBUsed}
+			original := collector.Metric{
+				Counter: counter, GPUUUID: gpuB, Value: "100",
+				Attributes: map[string]string{}, Labels: map[string]string{},
+			}
+			metrics, err := mapper.createPerProcessMetrics(original, counter, original, data,
+				func() dcgm.Field_Entity_Group { return dcgm.FE_GPU })
+			require.NoError(t, err)
+			require.Len(t, metrics, tc.wantSamples)
+			for _, metric := range metrics {
+				assert.Equal(t, gpuB, metric.GPUUUID)
+				assert.Equal(t, podUID, metric.Attributes[uidAttribute])
+				assert.Equal(t, "10", metric.Value)
+				if tc.direct {
+					assert.NotContains(t, metric.Attributes, vgpuAttribute)
+					assert.NotContains(t, metric.Labels, vgpuAttribute)
+					assert.NotContains(t, metric.Attributes, containerAttribute)
+				} else {
+					assert.Contains(t, metric.Attributes, vgpuAttribute)
+				}
+			}
+
+			// GPU_UTIL must continue to use the original candidate and slot mapping.
+			util, err := mapper.createPerProcessMetrics(original, counters.Counter{FieldName: metricGPUUtil}, original, data,
+				func() dcgm.Field_Entity_Group { return dcgm.FE_GPU })
+			require.NoError(t, err)
+			require.Len(t, util, len(tc.deviceToPods[gpuB]))
+			for _, metric := range util {
+				assert.Equal(t, "30", metric.Value)
+				assert.Contains(t, metric.Attributes, vgpuAttribute)
+			}
+		})
+	}
+}
+
+func TestCgroupMemoryAggregation(t *testing.T) {
+	mapper := &mockPIDMapper{
+		result:   map[uint32]*PodInfo{1: {UID: "pod-1"}, 2: {UID: "pod-1"}, 3: {UID: "pod-2"}},
+		errByPID: map[uint32]error{3: errors.New("process exited")},
+	}
+	c := &perProcessCollector{pidMapper: mapper}
+	memory := c.aggregatePodMemory(map[uint32]uint64{
+		1: 1536 * 1024, 2: 1536 * 1024, 3: 5 * 1024 * 1024, 4: 6 * 1024 * 1024,
+	})
+	assert.Equal(t, map[string]uint64{"pod-1": 3 * 1024 * 1024}, memory)
+}
+
+func TestCgroupMemoryEmptyCollectionDoesNotFallBackToSlots(t *testing.T) {
+	for _, name := range []string{"no processes", "NVML error", "nil client"} {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			devInfo := mockdeviceinfo.NewMockProvider(ctrl)
+			devInfo.EXPECT().GPUCount().Return(uint(1)).AnyTimes()
+			devInfo.EXPECT().GPU(uint(0)).Return(deviceinfo.GPUInfo{DeviceInfo: dcgm.Device{UUID: "GPU-1"}}).AnyTimes()
+			pod := PodInfo{UID: "pod-1", VGPU: "5"}
+			c := &perProcessCollector{cgroupDirect: true, pidMapper: &mockPIDMapper{result: map[uint32]*PodInfo{1: &pod}}}
+			if name != "nil client" {
+				client := mocknvmlprovider.NewMockNVML(ctrl)
+				var memory map[uint32]uint64
+				var err error
+				if name == "NVML error" {
+					memory, err = map[uint32]uint64{1: 10 * 1024 * 1024}, errors.New("NVML unavailable")
+				}
+				client.EXPECT().GetDeviceProcessMemory("GPU-1").Return(memory, err)
+				client.EXPECT().GetDeviceProcessUtilization("GPU-1").Return(nil, nil)
+				c.client = client
+			}
+			data := c.Collect(map[string]string{"GPU-1": "GPU-1"}, map[string][]PodInfo{"GPU-1": {pod}}, devInfo)
+			mapper := &PodMapper{Config: &appconfig.Config{}}
+			original := collector.Metric{GPUUUID: "GPU-1", Value: "100"}
+			metrics, err := mapper.createPerProcessMetrics(original, counters.Counter{FieldName: metricFBUsed}, original, data,
+				func() dcgm.Field_Entity_Group { return dcgm.FE_GPU })
+			require.NoError(t, err)
+			assert.NotNil(t, metrics, "an empty but handled result prevents logical-slot fallback")
+			assert.Empty(t, metrics)
+		})
+	}
+}
+
+func TestCgroupMemoryPreservesMIGCollection(t *testing.T) {
+	for _, withInstances := range []bool{false, true} {
+		t.Run(fmt.Sprintf("instances=%t", withInstances), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			client := mocknvmlprovider.NewMockNVML(ctrl)
+			gpu := deviceinfo.GPUInfo{DeviceInfo: dcgm.Device{UUID: "GPU-1"}, MigEnabled: true}
+			if withInstances {
+				gpu.GPUInstances = []deviceinfo.GPUInstanceInfo{{Info: dcgm.MigEntityInfo{NvmlInstanceId: 7}}}
+				client.EXPECT().GetAllMIGDevicesProcessMemory("GPU-1").Return(map[uint]map[uint32]uint64{7: {1: 1024 * 1024}}, nil).Times(2)
+			} else {
+				client.EXPECT().GetDeviceProcessMemory("GPU-1").Return(map[uint32]uint64{1: 1024 * 1024}, nil).Times(2)
+				client.EXPECT().GetDeviceProcessUtilization("GPU-1").Return(nil, nil).Times(2)
+			}
+			devInfo := mockdeviceinfo.NewMockProvider(ctrl)
+			devInfo.EXPECT().GPUCount().Return(uint(1)).AnyTimes()
+			devInfo.EXPECT().GPU(uint(0)).Return(gpu).AnyTimes()
+			pod := PodInfo{UID: "pod-1", VGPU: "5"}
+			c := &perProcessCollector{client: client, pidMapper: &mockPIDMapper{result: map[uint32]*PodInfo{1: &pod}}}
+			deviceMap := map[string]string{"GPU-1": "GPU-1"}
+			pods := map[string][]PodInfo{"GPU-1": {pod}, "0-7": {pod}}
+			before := c.Collect(deviceMap, pods, devInfo)
+			c.cgroupDirect = true
+			after := c.Collect(deviceMap, pods, devInfo)
+			assert.Equal(t, before, after)
+			assert.Empty(t, after.podMemory)
+		})
+	}
 }
 
 func TestGetGPUUUIDToDeviceID(t *testing.T) {

--- a/pkg/cmd/app.go
+++ b/pkg/cmd/app.go
@@ -102,6 +102,7 @@ const (
 	CLIContainerRuntimeSocket           = "container-runtime-socket"
 	CLINvidiaResourceNames              = "nvidia-resource-names"
 	CLIKubernetesVirtualGPUs            = "kubernetes-virtual-gpus"
+	CLIKubernetesProcessMappingMode     = "kubernetes-process-mapping-mode"
 	CLIDumpEnabled                      = "dump-enabled"
 	CLIDumpDirectory                    = "dump-directory"
 	CLIDumpRetention                    = "dump-retention"
@@ -354,6 +355,12 @@ func NewApp(buildVersion ...string) *cli.App {
 			Value:   false,
 			Usage:   "Capture metrics associated with virtual GPUs exposed by Kubernetes device plugins when using GPU sharing strategies, e.g. time-sharing or MPS.",
 			EnvVars: []string{"KUBERNETES_VIRTUAL_GPUS"},
+		},
+		&cli.StringFlag{
+			Name:    CLIKubernetesProcessMappingMode,
+			Value:   string(appconfig.ProcessMappingPodResources),
+			Usage:   "Choose Pod memory attribution: pod-resources or cgroup-direct. cgroup-direct applies only to non-MIG FB_USED and requires Kubernetes, virtual GPUs, and Pod UID labels.",
+			EnvVars: []string{"DCGM_EXPORTER_KUBERNETES_PROCESS_MAPPING_MODE"},
 		},
 		&cli.BoolFlag{
 			Name:    CLIDumpEnabled,
@@ -1439,6 +1446,7 @@ func defaultConfig() (*appconfig.Config, error) {
 		Kubernetes:                       false,
 		KubernetesEnablePodLabels:        false,
 		KubernetesEnablePodUID:           false,
+		KubernetesProcessMappingMode:     appconfig.ProcessMappingPodResources,
 		KubernetesGPUIdType:              appconfig.GPUUID,
 		KubernetesPodLabelAllowlistRegex: nil,
 		CollectDCP:                       true,
@@ -1598,6 +1606,9 @@ func applyExplicitConfigOverrides(c *cli.Context, config *appconfig.Config) erro
 	if c.IsSet(CLIKubernetesVirtualGPUs) {
 		config.KubernetesVirtualGPUs = c.Bool(CLIKubernetesVirtualGPUs)
 	}
+	if c.IsSet(CLIKubernetesProcessMappingMode) {
+		config.KubernetesProcessMappingMode = appconfig.KubernetesProcessMappingMode(c.String(CLIKubernetesProcessMappingMode))
+	}
 	if c.IsSet(CLIDumpEnabled) {
 		config.DumpConfig.Enabled = c.Bool(CLIDumpEnabled)
 	}
@@ -1663,6 +1674,16 @@ func applyConfigMapDataSource(config *appconfig.Config, configMapData string) er
 
 // validateConfig checks cross-field runtime requirements after all config sources are applied.
 func validateConfig(config *appconfig.Config) error {
+	switch config.KubernetesProcessMappingMode {
+	case appconfig.ProcessMappingPodResources:
+	case appconfig.ProcessMappingCgroupDirect:
+		if !config.Kubernetes || !config.KubernetesVirtualGPUs || !config.KubernetesEnablePodUID {
+			return fmt.Errorf("%s=cgroup-direct requires %s, %s, and %s", CLIKubernetesProcessMappingMode,
+				CLIKubernetes, CLIKubernetesVirtualGPUs, CLIKubernetesEnablePodUID)
+		}
+	default:
+		return fmt.Errorf("invalid %s parameter value: %q", CLIKubernetesProcessMappingMode, config.KubernetesProcessMappingMode)
+	}
 	if !slices.Contains(DCGMDbgLvlValues, config.DCGMLogLevel) {
 		return fmt.Errorf("invalid %s parameter value: %s", CLIDCGMLogLevel, config.DCGMLogLevel)
 	}

--- a/pkg/cmd/app_test.go
+++ b/pkg/cmd/app_test.go
@@ -494,6 +494,7 @@ func TestNewAppDefaultsMatchDefaultConfig(t *testing.T) {
 		assert.Empty(t, defaults.NvidiaResourceNames)
 		assert.Empty(t, c.StringSlice(CLINvidiaResourceNames))
 		assert.Equal(t, defaults.KubernetesVirtualGPUs, c.Bool(CLIKubernetesVirtualGPUs))
+		assert.Equal(t, string(defaults.KubernetesProcessMappingMode), c.String(CLIKubernetesProcessMappingMode))
 		assert.Equal(t, defaults.DumpConfig.Enabled, c.Bool(CLIDumpEnabled))
 		assert.Equal(t, defaults.DumpConfig.Directory, c.String(CLIDumpDirectory))
 		assert.Equal(t, defaults.DumpConfig.Retention, c.Int(CLIDumpRetention))
@@ -515,6 +516,47 @@ func TestNewAppDefaultsMatchDefaultConfig(t *testing.T) {
 	defaults, err := defaultConfig()
 	require.NoError(t, err)
 	assert.Equal(t, defaults, cfg)
+}
+
+func TestContextToConfigProcessMappingMode(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		args    []string
+		env     string
+		want    appconfig.KubernetesProcessMappingMode
+		wantErr string
+	}{
+		{name: "default", want: appconfig.ProcessMappingPodResources},
+		{name: "explicit default", args: []string{"--kubernetes-process-mapping-mode=pod-resources"}, want: appconfig.ProcessMappingPodResources},
+		{name: "direct", args: []string{"--kubernetes-process-mapping-mode=cgroup-direct", "--kubernetes", "--kubernetes-virtual-gpus", "--kubernetes-enable-pod-uid"}, want: appconfig.ProcessMappingCgroupDirect},
+		{name: "environment", env: "cgroup-direct", args: []string{"--kubernetes", "--kubernetes-virtual-gpus", "--kubernetes-enable-pod-uid"}, want: appconfig.ProcessMappingCgroupDirect},
+		{name: "CLI overrides environment", env: "cgroup-direct", args: []string{"--kubernetes-process-mapping-mode=pod-resources"}, want: appconfig.ProcessMappingPodResources},
+		{name: "invalid", args: []string{"--kubernetes-process-mapping-mode=unknown"}, wantErr: "invalid kubernetes-process-mapping-mode"},
+		{name: "missing Kubernetes", args: []string{"--kubernetes-process-mapping-mode=cgroup-direct", "--kubernetes-virtual-gpus", "--kubernetes-enable-pod-uid"}, wantErr: "requires"},
+		{name: "missing virtual GPUs", args: []string{"--kubernetes-process-mapping-mode=cgroup-direct", "--kubernetes", "--kubernetes-enable-pod-uid"}, wantErr: "requires"},
+		{name: "missing Pod UID", args: []string{"--kubernetes-process-mapping-mode=cgroup-direct", "--kubernetes", "--kubernetes-virtual-gpus"}, wantErr: "requires"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app := NewApp("test-version")
+			unsetFlagEnvVars(t, app.Flags)
+			if tc.env != "" {
+				t.Setenv("DCGM_EXPORTER_KUBERNETES_PROCESS_MAPPING_MODE", tc.env)
+			}
+			var cfg *appconfig.Config
+			app.Action = func(c *cli.Context) error {
+				var err error
+				cfg, err = contextToConfig(c)
+				return err
+			}
+			err := app.Run(append([]string{"dcgm-exporter"}, tc.args...))
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, cfg.KubernetesProcessMappingMode)
+		})
+	}
 }
 
 func TestStartDCGMExporterWithSignalSource_RejectsInvalidConfigBeforeDCGM(t *testing.T) {


### PR DESCRIPTION
Fixes #725

### Problem

PodResources-based attribution can miss pods when logical device assignments do not match actual physical GPU usage. It can also emit the same pod memory value once per logical slot.

### Solution

Add an optional `cgroup-direct` mode that reuses the existing per-process collector to aggregate NVML memory by physical GPU UUID and cgroup Pod UID.

- Emit one memory sample per observed pod on each GPU, without `vgpu` or container labels.
- Use cached Pod metadata for label enrichment, independently of device assignments.
- Preserve device totals and the default `pod-resources` mode. MIG and metrics other than `DCGM_FI_DEV_FB_USED` retain their existing behavior.

### Configuration

```bash
dcgm-exporter --kubernetes --kubernetes-virtual-gpus --kubernetes-enable-pod-uid \
  --kubernetes-process-mapping-mode=cgroup-direct
```

The mode can also be set with `DCGM_EXPORTER_KUBERNETES_PROCESS_MAPPING_MODE=cgroup-direct`.

Requires host process cgroup access, typically through `hostPID: true`, and Pod list/watch permissions for metadata. NVML must expose workload Pod PIDs; an MPS server PID alone cannot identify client Pods.

### Testing

Added mock-based tests for attribution, aggregation, failure handling, backward compatibility, labels, and configuration validation.

Passed on Linux/arm64:

```bash
CGO_ENABLED=1 go test ./internal/pkg/transformation ./internal/pkg/appconfig ./pkg/cmd \
  -short -count=1
```
